### PR TITLE
Update WebInkEnhancement explainer

### DIFF
--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -95,7 +95,7 @@ class InkRenderer {
         });
 
         if (this.presenter)
-            this.presenter.setLastRenderedPoint(evt.x, evt.y);
+            this.presenter.setLastRenderedPoint(evt);
     }
 
     void setPresenter(presenter) {
@@ -131,7 +131,7 @@ interface InkPresenter {
 
 interface PenStrokeTipPresenter : InkPresenter {
     void setPenStrokeStyle(PenStrokeStyle style);
-    void setLastRenderedPoint(Number x, Number y);
+    void setLastRenderedPoint(PointerEvent evt);
 }
 ```
 
@@ -149,6 +149,8 @@ We considered a few different locations for where the method `setLastRenderedPoi
   This seemed a bit too generic and scoping to a new namespace seemed appropriate.
 
 Instead of a concrete type, perhaps the `PenStrokeStyle` should be more generic in such a way that presenters can describe their capabilities via a dictionary. I'm not quite sure what the most ergonomic way of exposing this would be.
+
+Instead of providing `setLastRenderedPoint` with a PointerEvent, just providing x and y values is also an option. It was decided that a trusted pointer event would likely be the better option though, as then we can have easier access to the pointer ID and the web developer doesn't have to put extra thought into the position of the ink.
 
 ---
 [Related issues](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/WebInkEnhancement) | [Open a new issue](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?title=%5BWebInkEnhancement%5D)

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -70,6 +70,7 @@ const renderer = new InkRenderer();
 
 try {
     let presenter = await navigator.ink.requestPresenter('pen-stroke-tip');
+    renderer.setPresenter(presenter);
     window.addEventListener("pointermove", evt => {
         renderer.renderInkPoint(evt);
     });

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -93,8 +93,10 @@ class InkRenderer {
             this.renderStrokeSegment(event.x, event.y);
         });
 
-        if (this.presenter)
-            this.presenter.setLastRenderedPoint(evt, rgba(0, 0, 255, 0.5), 2);
+        if (this.presenter) {
+            this.presenterStyle = { color: "rgba(0, 0, 255, 0.5)", radius: 4 * evt.pressure };
+            this.presenter.setLastRenderedPoint(evt, this.presenterStyle);
+        }
     }
 
     void setPresenter(presenter) {
@@ -117,11 +119,16 @@ interface Ink {
     Promise<InkPresenter> requestPresenter(DOMString type);
 }
 
+dictionary PenStrokeStyle {
+    DOMString color;
+    unsigned long radius;
+}
+
 interface InkPresenter {
 }
 
 interface PenStrokeTipPresenter : InkPresenter {
-    void setLastRenderedPoint(PointerEvent evt, DOMString color, unsigned long radius);
+    void setLastRenderedPoint(PointerEvent evt, PenStrokeStyle style);
 }
 ```
 

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -146,7 +146,7 @@ We considered a few different locations for where the method `setLastRenderedPoi
 
   This seemed a bit too generic and scoping to a new namespace seemed appropriate.
 
-Due to uncertainty around the correct execution when `setLastRenderedPoint` is called before setting the stroke style, and it being likely that the radius could change frequently, we decided it may be best to require all 3 arguments (event, color, radius) in every call to `setLastRenderedPoint`.
+Due to uncertainty around the correct execution when `setLastRenderedPoint` is called before setting the stroke style, and it being likely that the radius could change frequently, we decided it may be best to require all relevant properties of rendering the ink stroke in every call to `setLastRenderedPoint`.
 
 Instead of providing `setLastRenderedPoint` with a PointerEvent, just providing x and y values is also an option. It was decided that a trusted pointer event would likely be the better option though, as then we can have easier access to the pointer ID and the web developer doesn't have to put extra thought into the position of the ink.
 


### PR DESCRIPTION
Update the WebInkEnhancement explainer to now have setLastRenderedPoint take in a trusted PointerEvent instead of just the x and y values of the pointer location.