### PR TITLE
Updating WebInkEnhancements explainer to include canvas and improvement metric

### DIFF
--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -67,11 +67,17 @@ As Pointer events gets delivered to an app, application continues rendering ink,
 ## Code example
 ```javascript
 const renderer = new InkRenderer();
+const minExpectedImprovement = 8;
 
 try {
     let presenter = await navigator.ink.requestPresenter('pen-stroke-tip', canvas);
-    if (presenter.expectedImprovement < 3)
+    
+    // With pointerraw events and javascript prediction, we can reduce latency
+    // by 16+ ms, so fallback if the InkPresenter is not capable enough to
+    // provide benefit
+    if (presenter.expectedImprovement < minExpectedImprovement)
         throw new Error("Little to no expected improvement, falling back");
+
     renderer.setPresenter(presenter);
     window.addEventListener("pointermove", evt => {
         renderer.renderInkPoint(evt);
@@ -146,7 +152,7 @@ Instead of providing `setLastRenderedPoint` with a PointerEvent, just providing 
 
 Providing the presenter with the canvas allows the boundaries of the drawing area to be determined. This is necessary so that points and ink outside of the desired area aren't drawn when points are being forwarded. If no canvas is provided, then the containing viewport size will be used.
 
-The `expectedImprovement` attribute exists to provide site authors with information regarding the perceived latency improvements they can expect by using this API. The attribute will return the expected average number of milliseconds that latency will be improved by using the API, including prediction.
+The `expectedImprovement` attribute exists to provide site authors with information regarding the perceived latency improvements they can expect by using this API. The attribute will return the expected average number of milliseconds that perceived latency will be improved by using the API, including prediction.
 
 
 ## Other options

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -72,7 +72,7 @@ try {
     let presenter = await navigator.ink.requestPresenter('pen-stroke-tip');
     let ctx = canvas.getContext('2d');
     renderer.setPresenter(presenter);
-    renderer.setCanvasContext(ctx);
+    renderer.setPresentationArea(canvas);
     window.addEventListener("pointermove", evt => {
         renderer.renderInkPoint(evt);
     });
@@ -106,8 +106,8 @@ class InkRenderer {
         this.presenter = presenter;
     }
     
-    void setCanvasContext(canvasContext) {
-        this.presenter.setPresentationArea(canvasContext);
+    void setPresentationArea(canvas) {
+        this.presenter.presentationArea = canvas;
     }
 
     renderStrokeSegment(x, y) {
@@ -136,7 +136,9 @@ interface InkPresenter {
 
 interface PenStrokeTipPresenter : InkPresenter {
     void setLastRenderedPoint(PointerEvent evt, PenStrokeStyle style);
-    void setPresentationArea(Element area);
+    
+    attribute Element presentationArea;
+    readonly attribute unsigned long expectedImprovement;
 }
 ```
 
@@ -157,7 +159,9 @@ Due to uncertainty around the correct execution when `setLastRenderedPoint` is c
 
 Instead of providing `setLastRenderedPoint` with a PointerEvent, just providing x and y values is also an option. It was decided that a trusted pointer event would likely be the better option though, as then we can have easier access to the pointer ID and the web developer doesn't have to put extra thought into the position of the ink.
 
-Providing the presenter with the canvas context allows the boundaries of the drawing area to be determined. This is necessary so that points and ink outside of the desired area aren't drawn when points are being forwarded.
+Providing the presenter with the canvas allows the boundaries of the drawing area to be determined. This is necessary so that points and ink outside of the desired area aren't drawn when points are being forwarded. If no canvas is provided, then the root layer size will be used.
+
+The `expectedImprovement` attribute exists to provide site authors with information regarding the perceived latency improvements they can expect by using this API. The attribute will return the expected average number of milliseconds that latency will be improved by using the API, including prediction.
 
 ---
 [Related issues](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/WebInkEnhancement) | [Open a new issue](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?title=%5BWebInkEnhancement%5D)

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -70,7 +70,9 @@ const renderer = new InkRenderer();
 
 try {
     let presenter = await navigator.ink.requestPresenter('pen-stroke-tip');
+    let ctx = canvas.getContext('2d');
     renderer.setPresenter(presenter);
+    renderer.setCanvasContext(ctx);
     window.addEventListener("pointermove", evt => {
         renderer.renderInkPoint(evt);
     });
@@ -103,6 +105,10 @@ class InkRenderer {
     void setPresenter(presenter) {
         this.presenter = presenter;
     }
+    
+    void setCanvasContext(canvasContext) {
+        this.presenter.setPresentationArea(canvasContext);
+    }
 
     renderStrokeSegment(x, y) {
         // application specific code to draw
@@ -130,6 +136,7 @@ interface InkPresenter {
 
 interface PenStrokeTipPresenter : InkPresenter {
     void setLastRenderedPoint(PointerEvent evt, PenStrokeStyle style);
+    void setPresentationArea(Element area);
 }
 ```
 
@@ -149,6 +156,8 @@ We considered a few different locations for where the method `setLastRenderedPoi
 Due to uncertainty around the correct execution when `setLastRenderedPoint` is called before setting the stroke style, and it being likely that the radius could change frequently, we decided it may be best to require all relevant properties of rendering the ink stroke in every call to `setLastRenderedPoint`.
 
 Instead of providing `setLastRenderedPoint` with a PointerEvent, just providing x and y values is also an option. It was decided that a trusted pointer event would likely be the better option though, as then we can have easier access to the pointer ID and the web developer doesn't have to put extra thought into the position of the ink.
+
+Providing the presenter with the canvas context allows the boundaries of the drawing area to be determined. This is necessary so that points and ink outside of the desired area aren't drawn when points are being forwarded.
 
 ---
 [Related issues](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/WebInkEnhancement) | [Open a new issue](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?title=%5BWebInkEnhancement%5D)

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -69,10 +69,8 @@ As Pointer events gets delivered to an app, application continues rendering ink,
 const renderer = new InkRenderer();
 
 try {
-    let presenter = await navigator.ink.requestPresenter('pen-stroke-tip');
-    let ctx = canvas.getContext('2d');
+    let presenter = await navigator.ink.requestPresenter('pen-stroke-tip', canvas);
     renderer.setPresenter(presenter);
-    renderer.setPresentationArea(canvas);
     window.addEventListener("pointermove", evt => {
         renderer.renderInkPoint(evt);
     });
@@ -105,10 +103,6 @@ class InkRenderer {
     void setPresenter(presenter) {
         this.presenter = presenter;
     }
-    
-    void setPresentationArea(canvas) {
-        this.presenter.presentationArea = canvas;
-    }
 
     renderStrokeSegment(x, y) {
         // application specific code to draw
@@ -132,9 +126,11 @@ dictionary PenStrokeStyle {
 }
 
 interface InkPresenter {
+    constructor(DOMString type, optional Element presentationArea);
 }
 
 interface PenStrokeTipPresenter : InkPresenter {
+    constructor(DOMString type, optional Element presentationArea);
     void setLastRenderedPoint(PointerEvent evt, PenStrokeStyle style);
     
     attribute Element presentationArea;


### PR DESCRIPTION
Added the optional canvas to the constructor for the presenter so that we know the size of the canvas to be drawn to. Also added in an attribute for the site authors to know how much of an improvement they can expect from this API.