### PR TITLE
Introduce SOTD

### DIFF
--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -1,11 +1,12 @@
-
-# MOVED: This Explainer is no longer maintained in this repo. Please follow: https://github.com/WICG/ink-enhancement/blob/master/README.md to find the current version. Thanks!
-
----
-
 # Web Ink Enhancement: Delegated Ink Trail Presentation Aided By The OS
 
 Author: [Daniel Libby](https://github.com/dlibby-)
+
+## Status of this Document
+This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for eventual standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
+* This document status: **ARCHIVED**
+* Expected | Current venue: [Web Incubator Community Group](https://wicg.io/) | [WICG/ink-enhancement](https://github.com/WICG/ink-enhancement) | ![GitHub issues](https://img.shields.io/github/issues/WICG/ink-enhancement)
+* Current version: [Explainer](https://github.com/WICG/ink-enhancement/blob/master/README.md)
 
 ## Introduction
 Achieving low latency is critical for delivering great inking experiences on the Web. Ink on the Web is generally produced by consuming PointerEvents and rendering strokes to the application view, whether that be 2D or WebGL canvas, or less commonly, SVG or even HTML.

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -3,7 +3,7 @@
 Author: [Daniel Libby](https://github.com/dlibby-)
 
 ## Status of this Document
-This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for eventual standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
+This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
 * This document status: **ARCHIVED**
 * Current venue: [W3C Web Incubator Community Group](https://wicg.io/) | [WICG/ink-enhancement](https://github.com/WICG/ink-enhancement) | ![GitHub issues](https://img.shields.io/github/issues/WICG/ink-enhancement)
 * Current version: [Explainer](https://github.com/WICG/ink-enhancement/blob/master/README.md)

--- a/WebInkEnhancement/explainer.md
+++ b/WebInkEnhancement/explainer.md
@@ -5,7 +5,7 @@ Author: [Daniel Libby](https://github.com/dlibby-)
 ## Status of this Document
 This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for eventual standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
 * This document status: **ARCHIVED**
-* Expected | Current venue: [Web Incubator Community Group](https://wicg.io/) | [WICG/ink-enhancement](https://github.com/WICG/ink-enhancement) | ![GitHub issues](https://img.shields.io/github/issues/WICG/ink-enhancement)
+* Current venue: [W3C Web Incubator Community Group](https://wicg.io/) | [WICG/ink-enhancement](https://github.com/WICG/ink-enhancement) | ![GitHub issues](https://img.shields.io/github/issues/WICG/ink-enhancement)
 * Current version: [Explainer](https://github.com/WICG/ink-enhancement/blob/master/README.md)
 
 ## Introduction


### PR DESCRIPTION
Expected format for future explainers' Status of this Document sections to help the community always find the latest version of the document. (Will include in explainer template following review.) Prior to transition to another venue, document status should be **Active**, and "Current venue" should read "Expected venue" so that the community knows where we expect this document to go next (if known). "Current version" can have a value of "this document".