### PR TITLE
Title change and replaced PWA with web app

### DIFF
--- a/TitleBarCustomization/explainer.md
+++ b/TitleBarCustomization/explainer.md
@@ -1,4 +1,4 @@
-# Title Bar Customization for Web Apps
+# Extend client area into titlebar
 
 ## Status of this Document
 This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.


### PR DESCRIPTION
Please take a look at the proposed changes. Travis recommended using nouns rather than verbs for the title so I've updated this to reflect Minimal-frame Window for Installed Desktop Web Apps.

It's long but descriptive and Travis didn't think the length was an issue. Only concern is minimal-frame may be confusing initially with minimal-ui but as it's not proposing a new display mode called minimal-frame I don't think the confusion will linger. 