### PR TITLE
Add 'Alternatives Considered' section

### DIFF
--- a/URLProtocolHandler/explainer.md
+++ b/URLProtocolHandler/explainer.md
@@ -144,7 +144,7 @@ As mentioned before, the Navigator interface from WebAPI has the method `registe
 
 ### Have `protocol_handlers` extend `registerProtocolHandler` with additional data
 
-[Issue #286](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/286) suggested that "this manifest addition serves to just 'enhance' the existing register protocol handler API." and that "the website still has to use the existing API". For instance, it could supplement the existing API with icons and other data that would be useful in an App context, but not as useful in a web site context.
+[Issue #286](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/286) suggested an alternative where "this manifest addition serves to just 'enhance' the existing register protocol handler API." and where "the website still has to use the existing API". For instance, it could supplement the existing API with icons and other data that would be useful in an App context, but not as useful in a web site context.
 
 Even though the author of the issue lists several good reasons as to why this could be an interesting alternative, this option will not be pursued because we believe this will not be ergonomic enough for developers. We could not find good examples on the web app space where manifest properties depend on calls to existing HTML5 APIs and having a dependency on that API being called at some point in time would work against the goal of having an app being able to handle protocols immediately after being installed.
 

--- a/URLProtocolHandler/explainer.md
+++ b/URLProtocolHandler/explainer.md
@@ -15,7 +15,7 @@ Eric Lawrence (<ericlaw@microsoft.com>)
 This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
 
 * This document status: **Active**
-* Expected venue: [Web Applications Working Group](https://www.w3.org/2019/webapps/) 
+* Expected venue: [Web Applications Working Group](https://www.w3.org/2019/webapps/)
 * Current version: this document
 
 ## Motivation
@@ -139,6 +139,16 @@ As mentioned before, the Navigator interface from WebAPI has the method `registe
 <https://html.spec.whatwg.org/multipage/system-state.html#custom-handlers>
 
 <https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler>
+
+## Alternatives Considered
+
+### Have `protocol_handlers` extend `registerProtocolHandler` with additional data
+
+[Issue #286](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/286) suggested that "this manifest addition serves to just 'enhance' the existing register protocol handler API." and that "the website still has to use the existing API". For instance, it could supplement the existing API with icons and other data that would be useful in an App context, but not as useful in a web site context.
+
+Even though the author of the issue lists several good reasons as to why this could be an interesting alternative, this option will not be pursued because we believe this will not be ergonomic enough for developers. We could not find good examples on the web app space where manifest properties depend on calls to existing HTML5 APIs and having a dependency on that API being called at some point in time would work against the goal of having an app being able to handle protocols immediately after being installed.
+
+Having the APIs interact with each other would also cause confusion with regards to the order of API calls: "Do I first call `registerProtocolHandler` and then install the app, or the other way around?", "If I uninstall the app and install it again, do I need to have the API called again?", etc. There's also plans to have `protocol_handlers` supported in browser extensions, and coming up with logical interactions for 3 registration scenarios would be even more confusing for developers.
 
 ## Security Considerations
 

--- a/URLProtocolHandler/explainer.md
+++ b/URLProtocolHandler/explainer.md
@@ -148,7 +148,7 @@ As mentioned before, the Navigator interface from WebAPI has the method `registe
 
 Even though the author of the issue lists several good reasons as to why this could be an interesting alternative, this option will not be pursued because we believe this will not be ergonomic enough for developers. We could not find good examples on the web app space where manifest properties depend on calls to existing HTML5 APIs and having a dependency on that API being called at some point in time would work against the goal of having an app being able to handle protocols immediately after being installed.
 
-Having the APIs interact with each other would also cause confusion with regards to the order of API calls: "Do I first call `registerProtocolHandler` and then install the app, or the other way around?", "If I uninstall the app and install it again, do I need to have the API called again?", etc. There's also plans to have `protocol_handlers` supported in browser extensions, and coming up with logical interactions for 3 registration scenarios would be even more confusing for developers.
+Having the APIs interact with each other would also cause confusion with regards to the order of API calls: "Do I first call `registerProtocolHandler` and then install the app, or the other way around?", "If I uninstall the app and install it again, do I need to have the API called again?", etc. There's also plans to have `protocol_handlers` supported in [browser extensions](https://bugs.chromium.org/p/chromium/issues/detail?id=64100), and coming up with logical interactions for 3 registration scenarios would be even more confusing for developers.
 
 ## Security Considerations
 


### PR DESCRIPTION
Resolve #286 by adding an "Alternatives Considered" section. We might expand that section as other ideas at the explainer level are suggested.

We debated the alternative proposed long and hard but ultimately feel that having the property being consumed at install time is the least confusing approach. The next step is addressing security concerns with that approach, tracked mainly in #230. We are still discussing that internally and will submit a PR soon.  

/cc @dmurph