### PR TITLE
Include the Status of this Document header for withdrawn explainers

### DIFF
--- a/Fragments/explainer.md
+++ b/Fragments/explainer.md
@@ -2,6 +2,11 @@
 
 Authors: [Aaron Gustafson](https://github.com/aarongustafson)
 
+## Status of this Document
+This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
+* This document status: **Withdrawn**
+* Note: We are now directing our efforts into providing feedback on the similar proposal [ScrollToTextFragment](https://github.com/WICG/ScrollToTextFragment/) already being incubated in the [W3C Web Incubator Community Group](https://wicg.io/).
+
 ## Introduction
 
 URLs have been a fantastic way to enable people to reference content on the web. With the addition of anchor points within Web documents (via `name` and `id`), authors were empowered to link to specific sections of a document or other documents across the web. Unfortunately, however, that utility requires action on the part of every web page author to include those anchor points. Numerous systems have cropped up to enable automated `id`-ing of headings (e.g., [Kramdown’s `auto_id_prefix`](https://kramdown.gettalong.org/options.html)), but they are seldom used. They are also limited to headings only and provide no direct access to flow content.

--- a/PasswordReveal/explainer.md
+++ b/PasswordReveal/explainer.md
@@ -2,6 +2,11 @@
 
 **Authors:** Bo Cupp, Alex Keng, Greg Whitworth
 
+## Status of this Document
+This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
+* This document status: **Withdrawn**
+* Note: Rather than working on this HTML controls feature in isolation, we have rolled this effort into the larger [Open UI](https://github.com/WICG/open-ui) project of the [Web Incubator Community Group](https://wicg.io/) in an effort to provide a standardized set of form controls for the web, including password.
+
 ## Motivation:
 
 Passwords have long been a pain point for users on the web. Newer standards and extensions have been introduced in hopes of resolving some of the problems to varying degrees of success.

--- a/Withdrawn/CustomDialogOnClose/explainer.md
+++ b/Withdrawn/CustomDialogOnClose/explainer.md
@@ -4,8 +4,10 @@
 
 -   Austin Orion
 
-## Withdrawn
-This explainer has been withdrawn. This design conflicted with the philosophy of keeping tab close as fast as possible. Work is ongoing to describe a way to meet the needs that this design aimed to address.
+## Status of this Document
+This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
+* This document status: **Withdrawn**
+* Note: This design conflicted with the philosophy of keeping tab close as fast as possible. Work is ongoing to describe a way to meet the needs that this design aimed to address.
 
 ## Introduction
 Installed PWAs need a way to allow developers to perform asynchronous operations (such as saving a file) and optionally show a customizable dialog before the user closes the app and their state is lost.


### PR DESCRIPTION
* Custom Dialog on Close
* Fragments
* Password Reveal

Text used for the note is borrowed from the Explainer's readme.md page.