### PR TITLE
Graduate window controls overlay explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,6 @@ we move them into the [Alumni section](#alumni-) below.
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Version%20History">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/Version%20History?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=aarongustafson%2C+stanleyhon&labels=Version+History&template=version-history.md)
-* [Window Controls Overlay for Installed Desktop Web Apps (was: Title Bar Customization)](TitleBarCustomization/explainer.md) | 
-    <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Window%20Controls%20Overlay">
-    ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/Window%20Controls%20Overlay?label=issues)</a> |
-    [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=amandabaker&labels=Window+Controls+Overlay&template=window-controls-overlay.md)
 
 ### Storage
 
@@ -161,6 +157,7 @@ standards communities. Thanks for your continued interest!
 
 | Archive date | Archived explainer | Category | Current document | Current standards venue |
 |--|--|--|--|--|
+| 2020-07-08 | [Window Controls Overlay for Installed Desktop Web Apps]() | Progressive Web Applications | [Window Controls Overlay for Installed Desktop Web Apps](https://github.com/WICG/window-controls-overlay/blob/master/explainer.md) | [Web Incubator Community Group]() |
 | 2020-05-28 | [PWAs as URL Handlers](PwaUriHandler/explainer.md) | Progressive Web Applications | [Progressive Web Apps as URL Handlers](https://github.com/WICG/pwa-url-handler/blob/master/explainer.md) | [Web Incubator Community Group](https://wicg.io/) |
 | 2020-03-17 | [EditContext API](EditContext/explainer.md) | Editing | [EditContext API Explainer](https://github.com/w3c/editing/blob/gh-pages/docs/EditContext/explainer.md) | [W3C Editing Task Force](https://w3c.github.io/editing/) |
 | 2020-03-13 | [Bidirectional WebDriver Protocol](WebDriverRPC/webdriver.md) | WebDriver | [Bidirectional WebDriver Protocol Explainer](https://github.com/w3c/webdriver-bidi/blob/master/explainer.md) | [WebDriver incubator of the W3C Browser Testing and Tools Working Group](https://github.com/w3c/webdriver/blob/master/README.md) |

--- a/TitleBarCustomization/explainer.md
+++ b/TitleBarCustomization/explainer.md
@@ -2,9 +2,9 @@
 
 ## Status of this Document
 This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
-* This document status: **Active**
-* Expected venue: [W3C Web Incubator Community Group](https://wicg.io/) 
-* Current version: this document
+* This document status: **ARCHIVED**
+* Current venue: [W3C Web Incubator Community Group](https://wicg.io/) 
+* Current version: https://github.com/WICG/window-controls-overlay/blob/master/explainer.md
     * See also: [w3c/manifest#847](https://github.com/w3c/manifest/issues/847)
     * See also: [w3c/csswg-drafts#4721](https://github.com/w3c/csswg-drafts/issues/4721)
     * See also: [WICG discourse thread](https://discourse.wicg.io/t/proposal-title-bar-customization-for-web-apps/4278)


### PR DESCRIPTION
Move the window controls overlay explainer from active to archived. 

To-do (presumably after completing this PR):
- Move issues to WICG repo
- Delete issue template: https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/templates/edit