### PR TITLE
Add open-ui links to 'Standardized control UI anatomy' section

### DIFF
--- a/ControlUICustomization/explainer.md
+++ b/ControlUICustomization/explainer.md
@@ -68,7 +68,7 @@ For the purposes of this document a 'part' is an element that has standardized m
 
 Rough examples:
 
-* The anatomy of a `<select>` could be defined as consisting of 1 'button' part containing 1 'selected-value' part and 1 popup 'listbox' part containing 0-N 'option' parts. At a very high level, the expected behavior of clicking the button is to expand the list, the expected behavior of the selected-value part is to keep its inner text updated to show the value of the currently selected option, the expected behavior of clicking outside the opened list is to collapse it, etc.  For a more detailed definition, see [Open UI `<select>` specification](https://open-ui.org/components/select).
+* The anatomy of a `<select>` could be defined as consisting of 1 'button' part containing 1 'selected-value' part and 1 popup 'listbox' part containing 0-N 'option' parts. At a very high level, the expected behavior of clicking the button is to expand the list, the expected behavior of the selected-value part is to keep its inner text updated to show the value of the currently selected option, the expected behavior of clicking outside the opened list is to collapse it, etc.  For a more detailed definition, see the [Open UI `<select>` specification](https://open-ui.org/components/select).
 * The anatomy of an `<input type="range">` could be defined as consisting of 1 draggable 'thumb' part that moves along 1 'track' part.
 
 When the developer provides a custom UI with the parts identified, the platform can apply native event handlers and ARIA roles to the elements designated as the parts to light up the control's expected behavior and accessibility without extra code from the developer.

--- a/ControlUICustomization/explainer.md
+++ b/ControlUICustomization/explainer.md
@@ -62,13 +62,13 @@ Web developers will have three options for customizing native controls:
 
 #### Standardized control UI anatomy, parts, and behavior
 
-One aspect of enabling this functionality for a given control type will be standardizing the anatomy of the control UI in terms of its conceptual parts and their behaviors, with standardized names for those parts.  This process is currently being driven by https://open-ui.org/.
+One aspect of enabling this functionality for a given control type will be standardizing the anatomy of the control UI in terms of its conceptual parts and their behaviors, with standardized names for those parts.  This process is currently being driven in https://open-ui.org/.
 
 For the purposes of this document a 'part' is an element that has standardized meaning to the control. This knowledge of those standardized parts allows the platform to wire up the necessary events and attributes to respond to user interaction which allow for a functional and accessible control (the "controller" code).
 
 Rough examples:
 
-* The anatomy of a `<select>` could be defined as consisting of 1 'button' part containing 1 'selected-value' part and 1 popup 'listbox' part containing 0-N 'option' parts. At a very high level, the expected behavior of clicking the button is to expand the list, the expected behavior of the selected-value part is to keep its inner text updated to show the value of the currently selected option, the expected behavior of clicking outside the opened list is to collapse it, etc.  For a more detailed definition, see https://open-ui.org/components/select.
+* The anatomy of a `<select>` could be defined as consisting of 1 'button' part containing 1 'selected-value' part and 1 popup 'listbox' part containing 0-N 'option' parts. At a very high level, the expected behavior of clicking the button is to expand the list, the expected behavior of the selected-value part is to keep its inner text updated to show the value of the currently selected option, the expected behavior of clicking outside the opened list is to collapse it, etc.  For a more detailed definition, see [Open UI `<select>` specification](https://open-ui.org/components/select).
 * The anatomy of an `<input type="range">` could be defined as consisting of 1 draggable 'thumb' part that moves along 1 'track' part.
 
 When the developer provides a custom UI with the parts identified, the platform can apply native event handlers and ARIA roles to the elements designated as the parts to light up the control's expected behavior and accessibility without extra code from the developer.

--- a/ControlUICustomization/explainer.md
+++ b/ControlUICustomization/explainer.md
@@ -62,13 +62,13 @@ Web developers will have three options for customizing native controls:
 
 #### Standardized control UI anatomy, parts, and behavior
 
-One aspect of enabling this functionality for a given control type will be standardizing the anatomy of the control UI in terms of its conceptual parts and their behaviors, with standardized names for those parts.
+One aspect of enabling this functionality for a given control type will be standardizing the anatomy of the control UI in terms of its conceptual parts and their behaviors, with standardized names for those parts.  This process is currently being driven by https://open-ui.org/.
 
 For the purposes of this document a 'part' is an element that has standardized meaning to the control. This knowledge of those standardized parts allows the platform to wire up the necessary events and attributes to respond to user interaction which allow for a functional and accessible control (the "controller" code).
 
 Rough examples:
 
-* The anatomy of a `<select>` could be defined as consisting of 1 'button' part containing 1 'selected-value' part and 1 popup 'listbox' part containing 0-N 'option' parts. At a very high level, the expected behavior of clicking the button is to expand the list, the expected behavior of the selected-value part is to keep its inner text updated to show the value of the currently selected option, the expected behavior of clicking outside the opened list is to collapse it, etc.
+* The anatomy of a `<select>` could be defined as consisting of 1 'button' part containing 1 'selected-value' part and 1 popup 'listbox' part containing 0-N 'option' parts. At a very high level, the expected behavior of clicking the button is to expand the list, the expected behavior of the selected-value part is to keep its inner text updated to show the value of the currently selected option, the expected behavior of clicking outside the opened list is to collapse it, etc.  For a more detailed definition, see https://open-ui.org/components/select.
 * The anatomy of an `<input type="range">` could be defined as consisting of 1 draggable 'thumb' part that moves along 1 'track' part.
 
 When the developer provides a custom UI with the parts identified, the platform can apply native event handlers and ARIA roles to the elements designated as the parts to light up the control's expected behavior and accessibility without extra code from the developer.


### PR DESCRIPTION
Add open-ui links to [Standardized control UI anatomy, parts, and behavior](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ControlUICustomization/explainer.md#standardized-control-ui-anatomy-parts-and-behavior) section.  Open-UI is already referenced in [Incremental Approach](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ControlUICustomization/explainer.md#incremental-approach) but it seems best to include it in the section about standardized anatomies as well since Open-UI is the venue for driving that process.

Context: #361 made me realize that Open UI wasn't really mentioned in the appropriate place.