### PR TITLE
Graduate popup to Open UI

### DIFF
--- a/Popup/explainer.md
+++ b/Popup/explainer.md
@@ -14,9 +14,9 @@ Authors:
 ## Status of this Document
 This document is a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
 
-* This document status: **Active**
-* Expected venue: [W3C Web Incubator Community Group](https://wicg.io/) / [Web Hypertext Application Technology Working Group (WHATWG)](https://whatwg.org/)
-* **Current version: this document**
+* This document status: **`ARCHIVED`**
+* Current venue: [Open UI Community Group](https://www.w3.org/community/open-ui/)
+* Current version: [Enabling popups](https://open-ui.org/components/popup.research.explainer)
 
 ## Introduction
 When building a web application, there are many cases in which an author needs to create transient user interface (UI) elements that are displayed on top of all other web app UI. These include user-interactive elements like action menus, form element suggestions, content pickers, and teaching UI. These paradigms will be collectively referred to as *popups*.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ standards communities. Thanks for your continued interest!
 
 | Current Explainer | Current Venue | Archive link and date |
 |---|---|---|
-| [Enabling popups](https://open-ui.org/components/popup.research.explainer) | [Open UI CG](https://www.w3.org/community/open-ui/) | [2021-03-22](Popup/explainer.md) |
+| [Enabling popups](https://open-ui.org/components/popup.research.explainer) | [Open UI Community Group](https://www.w3.org/community/open-ui/) | [2021-03-22](Popup/explainer.md) |
 | [PARAKEET](https://github.com/WICG/privacy-preserving-ads/blob/main/Parakeet.md) | [Web Incubator Community Group](https://wicg.io/) | 2021-03-04 |
 | [Canvas Formatted Text](https://github.com/WICG/canvas-formatted-text/blob/main/README.md) | [Web Incubator Community Group](https://wicg.io/) | [2020-09-23](Canvas/FormattedText.md) |
 | [Window Controls Overlay for Installed Desktop Web Apps](https://github.com/WICG/window-controls-overlay/blob/master/explainer.md) | [Web Incubator Community Group](https://wicg.io/) | [2020-07-08](TitleBarCustomization/explainer.md) |

--- a/README.md
+++ b/README.md
@@ -101,10 +101,6 @@ we move them into the [Alumni section](#alumni-) below.
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/EyeDropper">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/EyeDropper?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=BoCupp-Microsoft&labels=EyeDropper&template=eyedropper.md&title=%5BEyeDropper%5D+%3CTITLE+HERE%3E)
-* [Popup](Popup/explainer.md) |
-    <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Popup">
-    ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/Popup?label=issues)</a> |
-    [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=melanierichards%2C+BoCupp-Microsoft%2C+ipopescu93&labels=Popup&template=popup.md&title=%5BPopup%5D+%3CTITLE+HERE%3E)
 
 ### Media
 
@@ -181,6 +177,7 @@ standards communities. Thanks for your continued interest!
 
 | Current Explainer | Current Venue | Archive link and date |
 |---|---|---|
+| [Enabling popups](https://open-ui.org/components/popup.research.explainer) | [Open UI CG](https://www.w3.org/community/open-ui/) | [2021-03-22](Popup/explainer.md) |
 | [PARAKEET](https://github.com/WICG/privacy-preserving-ads/blob/main/Parakeet.md) | [Web Incubator Community Group](https://wicg.io/) | 2021-03-04 |
 | [Canvas Formatted Text](https://github.com/WICG/canvas-formatted-text/blob/main/README.md) | [Web Incubator Community Group](https://wicg.io/) | [2020-09-23](Canvas/FormattedText.md) |
 | [Window Controls Overlay for Installed Desktop Web Apps](https://github.com/WICG/window-controls-overlay/blob/master/explainer.md) | [Web Incubator Community Group](https://wicg.io/) | [2020-07-08](TitleBarCustomization/explainer.md) |


### PR DESCRIPTION
Open UI CG took up `<popup>` as an incubation work item, with the intent of eventually filing PRs against the HTML Living Standard in WHATWG. This PR graduates the explainer, and issue porting will follow.