### PR TITLE
Add focusgroup attribute Zoom video recording

### DIFF
--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -13,7 +13,11 @@ most current standards venue and content location of future work and discussions
 * This document status: **Active**
 * Expected venue: [WHATWG HTML Workstream](https://whatwg.org/workstreams#:~:text=html)
 * **Current version: this document**
-    
+
+**⭐New: A video recording of 
+[a presentation of this explainer to the W3C Open UI community group](https://us02web.zoom.us/rec/play/M9CQws3fPYB6vzKjvjJi6uVgYbzHKZ2L5pWpZ-A_VNUa8SbPiqsZFoGX4TmbgClfIo2RHZdeHxoi3gyN.BJWX3lSoah5ddYDW?continueMode=true&_x_zm_rtaid=vgoo4d78TTmnS6SlqvSKQw.1631896465490.797a543ba5ef0034680f19392aa6a088&_x_zm_rhtaid=706)
+is now available.**
+
 ## 1. Introduction
 
 When writing custom controls, authors need to implement the semantics of various known

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ we move them into the [Alumni section](#alumni-) below.
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Custom%20Control%20UI">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/Custom%20Control%20UI?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=dandclark&labels=Custom+Control+UI&template=custom-control-ui.md&title=%5BEnabling+Custom+Control+UI%5D+%3CTITLE+HERE%3E)
-* [`focusgroup` attribute](Focusgroup/explainer.md) |
+* [`focusgroup` attribute](Focusgroup/explainer.md) ([video overview](https://us02web.zoom.us/rec/play/M9CQws3fPYB6vzKjvjJi6uVgYbzHKZ2L5pWpZ-A_VNUa8SbPiqsZFoGX4TmbgClfIo2RHZdeHxoi3gyN.BJWX3lSoah5ddYDW?continueMode=true&_x_zm_rtaid=vgoo4d78TTmnS6SlqvSKQw.1631896465490.797a543ba5ef0034680f19392aa6a088&_x_zm_rhtaid=706)) |
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/focusgroup">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/focusgroup?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=travisleithead&labels=focusgroup&template=focusgroup.md&title=%5Bfocusgroup%5D+%3CTITLE+HERE%3E)


### PR DESCRIPTION
Travis presented to the W3C Open UI CG on 9/16/2021. They made the video recording public. It provides a visual presentation of the background, principles, limitations, and use cases of the feature.

https://us02web.zoom.us/rec/play/M9CQws3fPYB6vzKjvjJi6uVgYbzHKZ2L5pWpZ-A_VNUa8SbPiqsZFoGX4TmbgClfIo2RHZdeHxoi3gyN.BJWX3lSoah5ddYDW?continueMode=true&_x_zm_rtaid=vgoo4d78TTmnS6SlqvSKQw.1631896465490.797a543ba5ef0034680f19392aa6a088&_x_zm_rhtaid=706