### PR TITLE
Update focusgroup explainer

### DIFF
--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -24,24 +24,26 @@ combo boxes, accordion panels, carousels, focusable grid tables, etc. Many of th
 patterns expect arrow-key navigation, as well as support for page down/up, home/end, even
 "type ahead" behavior. 
 
-The native HTML platform supports some of these linear navigation behaviors in native
+The native web platform supports *some* of these linear navigation behaviors in native
 controls like radio button groups (wrap-around arrow key movement that changes both focus
 and linked selection), &lt;select&gt; element popups (up/down movement among options), and 
-date-time controls (arrow key movement among the components of the date), but does not 
-expose a primitive that can be used independently to get this behavior. 
+date-time controls (arrow key movement among the components of the date), but **does not 
+expose a primitive** that can be used independently to get this behavior. 
 
-We propose an attribute 'focusgroup' that will facilitate focus navigation (not selection)
-using arrow keys among a set of focusable elements. The attribute can then be used 
+We propose exposing a new web platform primitive—'focusgroup'—to facilitate focus navigation (not selection)
+using arrow keys among a set of focusable elements. This feature can then be used 
 (**without any JavaScript**) to easily supply platform-provided focus group navigation into
 custom-authored controls in a standardized and predictable way for users.
 
 Customers like Microsoft's Fluent UI team are excited to leverage this built-in capacity
-for the advantages of consistency, accessibility by default, and promised interoperability
+for its keyboard consistency, default accessibility (provides a signal to ATs for alternate 
+keyboard navigation), and promised interoperability
 over existing solutions.
 
 While this document emphasizes the usage of the keyboard arrow keys for accessibility
 navigation, we acknowledge that there are other input modalities that work (or can be adapted 
-to work) equally well for focusgroup navigation behavior.
+to work) equally well for focusgroup navigation behavior (e.g., game controllers, gesture 
+recognizers, touch-based ATs, etc.)
 
 ## 2. Goal
 
@@ -58,56 +60,53 @@ implementing the pattern:
 * [FocusZone in Fluent UI](https://developer.microsoft.com/en-us/fluentui#/controls/web/focuszone)
 * [Elix component library's KeyboardDirectionMixin](https://component.kitchen/elix/KeyboardDirectionMixin)
 
-To achieve this goal, we believe that the solution must be done with declarative markup.
+To achieve this goal, we believe that the solution must be done with declarative markup or CSS.
 If JavaScript is required, then there seems little advantage to using a built-in feature over
 what can be implemented completely in author code. Furthermore, a declarative solution provides
 the key signal that allows the platform's accessibility infrastructure to make the group 
 accessible by default:
 
-* Signaling to the AT that arrow-key navigation, etc. can be used in the region, and that the 
-   user has entered a region where it is available.
-* Understanding the bounds/extent of the region, providing list context like "X in Y items" 
+* Signaling to the AT that arrow-key navigation can be used on the focused element.
+* Understanding the bounds/extent of the group, providing list context like "X in Y items" 
    (posinset/setsize)
 * Providing a consistent and reliable navigation usage pattern for users with no extra author code
    required.
 
 ## 3. Non-Goals
 
-It's worth noting that in most roving tabindex implementations, the notion of moving *focus* is 
+In most roving tabindex implementations, the notion of moving *focus* is 
 tightly coupled with the notion of *selection*. In some cases, it makes sense to have selection follow
 the focus, but in other scenarios these need to be decoupled. For this proposed standard, we decouple 
-selection from focus and only focus (cough) on the focus aspect and the movement of focus using the
-keyboard among eligible focus targets. Adding selection state--in essence a "memory" of where to
-restore focus when moving into or out of the group is left as an exercise for authors (there are 
-usually additional "actions" necessary to activate a selection and extra considerations for handling
-multiple selection that adds further complications).
+selection from focus and only focus (cough) on the focus aspect: moving focus using the
+keyboard among eligible focus targets. Adding selection state, e.g., tracking the currently selected 
+option in a list, will be a separate feature. To handle selection-based scenarios, we defer to the 
+CSS proposal [**Toggles**](https://tabatkins.github.io/css-toggle/) which can work nicely with focusgroups.
 
-No additional UI (e.g., "focus ring") is associated with the proposed 'focusgroup' attribute. It 
+No additional UI (e.g., a "focus ring") is associated with focusgroups. A focusgroup
 is wholly intended as a logical (transparent) grouping mechanism for a set of already focusable child elements,
 providing arrow key navigation among them. All the pre-existing styling/ native UI affordances for
 focus tracking are unchanged with this proposal.
 
 ## 4. Principles
 
-1. Intuitive use in markup. Focusgroups
-    * are easy to reason about (self-documenting) in the source markup.
-    * can be "extended" to apply their semantics naturally with the DOM hierarchy.
-    * provide a logical interaction between nested focusgroups. 
-    * blend in and play well with existing HTML semantics focus semantics
+1. Intuitive use in declarative scenarios. Focusgroups
+    * are easy to reason about (self-documenting) in the source markup or CSS.
+    * provide an intuitive interaction between focusgroups.
+    * integrate well with other related platform semantics.
 2. Focusgroups are easy to maintain and configure.
-    * Configuration should be done ideally in one place per focusgroup.
-    * Avoid extra configuration attributes: fit into existing HTML attribute value patterns.
-    * Avoid "spidery" linking using IDRefs or custom names that could lead to conflicts or
-       unexpected focusgroup inclusions.
-3. HTML-based "API" (versus using CSS properties).
-    * Focusgroup are intended for content model navigation (not the visual presentation of CSS). 
-       Couching the feature as an HTML "API" reinforces this principle. Additionally, like other
-       existing built-in HTML controls, focusgroup navigation follows DOM order to compliment
-       accessibility patterns.
+    * Configuration is managed in one place.
+    * Provide easy to understand usage into HTML and CSS patterns.
+    * Avoid "spidery connections" e.g., using IDRefs or custom names that are hard to maintain.
+3. Complimentary declarative representations in HTML and CSS
+    * HTML attributes offers focusgroup usage directly with impacted content and provide for
+       the most straightforward scenarios.
+    * CSS properties allow for responsive design patterns to conditionally apply focusgroup 
+       behavior under changing layouts. Enables some advanced use cases where selector-based
+       matching is advantageous.
      
 ## 5. Use Cases
 
-1. A set of focusable controls parented by one element can be trivially added to a focusgroup.
+1. Group a set of focusable child elements under a single focusgroup.
 2. A set of focusable controls spanning a hierarchy of DOM can be added to a single logical 
     focusgroup.
 3. A logical focusgroup can be configured to have wrap-around focus semantics if desired.

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -32,7 +32,7 @@ expose a primitive** that can be used independently to get this behavior.
 
 We propose exposing a new web platform primitive—'focusgroup'—to facilitate focus navigation (not selection)
 using arrow keys among a set of focusable elements. This feature can then be used 
-(**without any JavaScript**) to easily supply platform-provided focus group navigation into
+(**without any JavaScript**) to easily supply platform-provided focusgroup navigation into
 custom-authored controls in a standardized and predictable way for users.
 
 Customers like Microsoft's Fluent UI team are excited to leverage this built-in capacity
@@ -119,8 +119,8 @@ focus tracking are unchanged with this proposal.
 7. (Multiple focusgroups) Multiple focusgroups can be established on a single element (advanced CSS 
     scenario).
 8. (Opt-out) Individual elements can opt-out of focusgroup participation (advanced CSS scenario)
-9. (Grid) Focusgroups can be used for grid-type navigation (structured content grids like &lt;table&gt;,
-    not "presentation" grids).
+9. (Grid) Focusgroups can be used for grid-type navigation (&lt;table&gt;-structured content or other
+    grid-like structured content (advanced CSS scenario), but not "presentation" grids).
 
 ## 6. Focusgroup Concepts
 
@@ -134,14 +134,15 @@ Linear focusgroups provide arrow key navigation among a *list* of elements. Grid
 arrow key navigation behavior for tabular (or 2-dimensional) data structures.
 
 Multiple linear focusgroups can be combined together into one logical focusgroup, but linear focusgroups
-cannot be combined with grid focusgroups and vice-versa.
+cannot be combined with grid focusgroups and vice-versa (and grid focusgroups cannot be combined with
+each other).
 
 Focusgroups consist of a **focusgroup definition** that establish **focusgroup candidates** and
 **focusgroup items**. Focusgroup definitions manage the desired behavior for the associated focusgroup 
 items. Focusgroup items are the elements that actually participate in the focusgroup (among the possible
 focusgroup candidates).
 
-When a focusgroup definition is associated with an element, all of that element's direct children
+When a linear focusgroup definition is associated with an element, all of that element's direct children
 become focusgroup candidates. Focusgroup candidates become focusgroup items if they are focusable, e.g.,
 implicitly focusable elements like `<button>`, or explicitly made focusable via `tabindex` or some
 other mechanism (e.g., `contenteditable`).
@@ -178,12 +179,12 @@ of the tabindex sequential navigation ordering).
 
 Focusgroup definitions may include the following (in addition to a name):
 
-* extend -- a mechanism to join this focus group to an ancestor focusgroup. Note: linear focusgroups cannot
-   be joined to grid focusgroups and vice versa.
+* extend -- applies to linear focusgroups only: a mechanism to join this linear focusgroup to an ancestor 
+   linear focusgroup.
 * direction -- applies to linear focusgroups only: constrains the keys used for arrow key navigation to 
    horizontal, vertical, or both (the default).
 * wrap -- what to do when the attempting to move past the end of a focusgroup. The default/initial value is 
-   nowrap which means that focus is not moved past the end of a focus group with the arrow keys.
+   nowrap which means that focus is not moved past the end of a focusgroup with the arrow keys.
 
 In HTML these focusgroup definitions are applied as space-separated token values to the `focusgroup` 
 attribute. In CSS, these definitions are specified as properties (including a `focus-group` shorthand
@@ -280,7 +281,7 @@ to be used to "exit" these trapping elements).
 
 ### 6.3. Enabling wrapping behaviors
 
-By default, focusgroup traversal with arrow keys ends at boundaries of the focus group (the start and
+By default, focusgroup traversal with arrow keys ends at boundaries of the focusgroup (the start and
 end of a linear focusgroup, and the start and end of both rows and columns in a grid focusgroup). The 
 following focusgroup definition values can configure this:
 

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -306,7 +306,7 @@ same grid. If this combination of behavior is needed, we want to hear this feedb
 
 By default, a focusgroup definition's focusgroup candidates are its direct children. To "extend the
 reach" of a linear focusgroup's candidates, a linear focusgroup definition can declare that it intends
-to `extend` an ancestor linear focusgroup. If there is an anscestor linear focusgroup of the same name,
+to `extend` an ancestor linear focusgroup. If there is an ancestor linear focusgroup of the same name,
 the extending focusgroup becomes an extension of that ancestor's focusgroup. Extending a linear 
 focusgroup is also an opportunity to change the directionality (and, conditionally, the wrappping) of
 the newly extended focusgroup candidates (as described later).
@@ -314,7 +314,7 @@ the newly extended focusgroup candidates (as described later).
 Using `extend` in a focusgroup definition is only valid for linear focusgroups. Grid focusgroups 
 **cannot** use `extend` to become a part of linear focusgroup. Similarly, linear focusgroups **cannot**
 use `extend` to become part of a grid focusgroup. And grid focusgroups cannot use `extend` to join
-an anscestor grid focusgroup.
+an ancestor grid focusgroup.
 
 Below, the `<my-accordion>` element with a focusgroup attribute defines a focusgroup with nothing
 focusable in it; the focusable `<button>` elements are separated by an `<h3>` element. The `<h3>` and 
@@ -484,7 +484,7 @@ Example 11:
 <style>
   horizontal-menu {
     focus-group-name: auto;
-    focus-group-direction: wrap;
+    focus-group-direction: horizontal;
     focus-group-wrap: wrap;
   }
   omni-menu {

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -858,7 +858,6 @@ name of `gridrows` automatically creates row focusgroup candidates on
 its children. Similarly, a focusgroup name of `gridcells` automatically creates
 cell focusgroup candidates on its children.
 
-`gridrows` and `gridcells` are both necessary to create a proper grid focusgroup.
 Elements with the `gridcells` focusgroup definition must be descendants of an
 element with a `gridrows` focusgroup definition (but not necessarily direct 
 children of each other).

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -278,9 +278,7 @@ Some built-in controls like `<input type=text>` "trap" nearly all keys that woul
 focusgroup. This proposal does not provide a way to prevent this from happening (Tab should continue
 to be used to "exit" these trapping elements).
 
-### 6.3. Configuring and customizing the focusgroup
-
-#### 6.3.1. Wrapping behaviors
+### 6.3. Enabling wrapping behaviors
 
 By default, focusgroup traversal with arrow keys ends at boundaries of the focus group (the start and
 end of a linear focusgroup, and the start and end of both rows and columns in a grid focusgroup). The 
@@ -289,52 +287,63 @@ following focusgroup definition values can configure this:
 | HTML attribute value | CSS property & value | Explanation |
 |----------------------|----------------------|-------------|
 | focusgroup="wrap" | focus&#8209;group&#8209;wrap:&nbsp;wrap | **linear focusgroup**: causes movement beyond the ends of the focusgroup to wrap around to the other side; **grid focusgroup**: causes focus movement at the ends of the rows/columns to wrap around to the opposite side of the same rows/columns |
-| focusgroup="nowrap" | focus&#8209;group&#8209;wrap:&nbsp;nowrap | Disables any kind of wrapping (the initial/default value) |
+| focusgroup="" (unspecified) | focus&#8209;group&#8209;wrap:&nbsp;nowrap | Disables any kind of wrapping (the initial/default value) |
 
 The following are only applicable to grid focusgroups:
 
 | HTML attribute value | CSS property & value | Explanation |
 |----------------------|----------------------|-------------|
-| focusgroup="row-wrap" | focus&#8209;group&#8209;wrap:&nbsp;row&#8209;wrap | Rows wrap around, but column wrapping [and flowing as described below] is disabled. |
-| focusgroup="col-wrap" | focus&#8209;group&#8209;wrap:&nbsp;col&#8209;wrap | Columns wrap around, but row wrapping [and flowing as described below] is disabled. |
+| focusgroup="row&#8209;wrap" | focus&#8209;group&#8209;wrap:&nbsp;row&#8209;wrap | Rows wrap around, but column wrapping [and flowing as described below] is disabled. |
+| focusgroup="col&#8209;wrap" | focus&#8209;group&#8209;wrap:&nbsp;col&#8209;wrap | Columns wrap around, but row wrapping [and flowing as described below] is disabled. |
 | focusgroup="flow" | focus&#8209;group&#8209;wrap:&nbsp;flow | Movement past the end of a row wraps the focus to the beginning of **the next row**. Movement past the beginning of a row wraps focus back to the end of **the prior row**. Same for columns. The last row/column wraps to the first row/column and vice versa. |
-| focusgroup="row-flow" | focus&#8209;group&#8209;wrap:&nbsp;row&#8209;flow | Rows "flow" from row ends to the next/prior row as described above, but column flowing/wrapping is disabled. |
-| focusgroup="col-flow" | focus&#8209;group&#8209;wrap:&nbsp;col&#8209;flow | Columns "flow" from column ends to the next/prior column as described above, but row flowing/wrapping is disabled. |
+| focusgroup="row&#8209;flow" | focus&#8209;group&#8209;wrap:&nbsp;row&#8209;flow | Rows "flow" from row ends to the next/prior row as described above, but column flowing/wrapping is disabled. |
+| focusgroup="col&#8209;flow" | focus&#8209;group&#8209;wrap:&nbsp;col&#8209;flow | Columns "flow" from column ends to the next/prior column as described above, but row flowing/wrapping is disabled. |
 
 No option is provided for the hybrid condition of row wrap + column flow behavior (or vice-versa) in the 
 same grid. If this combination of behavior is needed, we want to hear this feedback.
 
-#### 6.3.2. 'extend' - Extending the focusgroup
+### 6.4. Expanding and connecting linear focusgroups together (`extend`)
 
-By default, the focusgroup's scope only covers its direct children. To extend the reach of the focusgroup,
-simply declare a second focusgroup attribute on one of the original focusgroup's direct children, and 
-indicate that this group will extend the parent's group. It becomes an extension of the original group.
+By default, a focusgroup definition's focusgroup candidates are its direct children. To "extend the
+reach" of a linear focusgroup's candidates, a linear focusgroup definition can declare that it intends
+to `extend` an ancestor linear focusgroup. If there is an anscestor linear focusgroup of the same name,
+the extending focusgroup becomes an extension of that ancestor's focusgroup. Extending a linear 
+focusgroup is also an opportunity to change the directionality (and, conditionally, the wrappping) of
+the newly extended focusgroup candidates (as described later).
 
-Below, the `<my-accordion>` element with a focusgroup attribute defines a focusgroup with nothing focusable
-in it. :( This is because the focusable `<button>` elements are separated by a level in the hierarchy:
+Using `extend` in a focusgroup definition is only valid for linear focusgroups. Grid focusgroups 
+**cannot** use `extend` to become a part of linear focusgroup. Similarly, linear focusgroups **cannot**
+use `extend` to become part of a grid focusgroup. And grid focusgroups cannot use `extend` to join
+an anscestor grid focusgroup.
+
+Below, the `<my-accordion>` element with a focusgroup attribute defines a focusgroup with nothing
+focusable in it; the focusable `<button>` elements are separated by an `<h3>` element. The `<h3>` and 
+`<div>` elements are the focusgroup candidates, and are not focusable:
 
 Example 4:
 ```html
-<my-accordion focusgroup> 
-  <h3><button aria-expanded=true aria-controls=p1>Panel 1</button></h3> 
-  <div id=p1 role=region>Panel 1 contents</div> 
-  <h3><button aria-expanded=true aria-controls=p2>Panel 2</button></h3> 
-  <div id=p2 role=region>Panel 2 contents</div> 
+<my-accordion focusgroup>
+  <h3><button aria-expanded=true aria-controls=p1>Panel 1</button></h3>
+  <div id=p1 role=region>Panel 1 contents</div>
+  <h3><button aria-expanded=true aria-controls=p2>Panel 2</button></h3>
+  <div id=p2 role=region>Panel 2 contents</div>
 </my-accordion> 
 ```
 
-To make the `<button>`s belong to one focusgroup, the `<h3>`s need to extend the group. Note that the element
-that does the extension does not itself have to be focusable:
+To make the `<button>`s belong to one focusgroup, a focusgroup definition must placed on the `<h3>`
+elements that explicitly declares `extend`, causing `<h3>` children to become focusgroup candidates.
 
 Example 5:
-```html
-<my-accordion focusgroup> 
-  <h3 focusgroup="extend"><button aria-expanded=true aria-controls=p1>Panel 1</button></h3> 
-  <div id=p1 role=region>Panel 1 contents</div> 
-  <h3 focusgroup="extend"><button aria-expanded=true aria-controls=p2>Panel 2</button></h3> 
-  <div id=p2 role=region>Panel 2 contents</div> 
-</my-accordion> 
+```css
+my-accordion[focusgroup] > h3 {
+   focus-group-name: auto extend;
+}
 ```
+
+The `extend` value employs an ancestor lookup to attempt to locate-and-extend a same-named
+linear focusgroup. It is not necessary that an extending linear focusgroup be a direct
+child of an existing focusgroup. The first-located focusgroup definition in the ancestor 
+chain of elements is the focusgroup definition that is considered for extending.
 
 When extending a focusgroup, traversal order is based on document order. Given the following: 
 
@@ -342,9 +351,13 @@ Example 6:
 ```html
 <div focusgroup> 
   <div id=A tabindex=0></div> 
-  <div id=B tabindex=-1 focusgroup=extend> 
-    <div id=B1 tabindex=-1></div> 
-    <div id=B2 tabindex=-1></div> 
+  <div id=B tabindex=-1>
+    <div>
+      <div focusgroup=extend>
+        <div id=B1 tabindex=-1></div> 
+        <div id=B2 tabindex=-1></div>
+      </div>
+    </div>
   </div> 
   <div id=C tabindex=-1></div> 
 </div> 
@@ -353,18 +366,22 @@ Example 6:
 Sequentially pressing the right arrow (assuming `horizontal-tb` + LTR writing-mode) would move
 through the `<div>`s: A, B, B1, B2, C. (And in reverse direction: C, B2, B1, B, A, as expected.)
 
-Certain configuration values are extended down from parent to child, for example `wrap`. It does
-not need to be repeated in an extending focusgroup. Specifying `wrap` on any extending focusgroup
-when it is not specified on a parent focusgroup may or may not apply (more on that later). In this
-case it would not apply (no wrapping behavior) because the child focusgroup (id=B) extended a 
-[no-wrap] state from its parent focusgroup and will use that value regardless of the presence of 
-`wrap`:
+Unless otherwise explicitly changed, focusgroup definition state of the ancestor is applied to
+the extending focusgroup definition: wrapping and direction. These directives do not need to be
+repeated in an extending focusgroup.
+
+Under certain conditions (explained later), the extended state can't be changed. For
+example: specifying `wrap` on an extending focusgroup definition when "nowrap" (even implicitly)
+was specified on a parent focusgroup does not make sense; the extending focusgroup candidates
+join the rest of the ancestor focusgroup candidates to form one logical ordering--they do not
+define a separate range of focusgroup candidates to apply different wrapping logic onto.
 
 Example 7:
 ```html
+<!-- This is an example of what NOT TO DO -->
 <div focusgroup> 
   <div id=A tabindex=0></div> 
-  <div id=B tabindex=-1 focusgroup="extend wrap"> 
+  <div id=B tabindex=-1 focusgroup="extend wrap"> <!-- 'wrap' will not apply -->
     <div id=B1 tabindex=-1></div> 
     <div id=B2 tabindex=-1></div> 
   </div> 
@@ -372,18 +389,35 @@ Example 7:
 </div> 
 ```
 
-#### 6.3.3. 'horizontal' and 'vertical' - limiting navigation directionality
+In this, `wrap` specified on the extending focusgroup definition will not cause any wrapping
+behavior to apply. The extending focusgroup (id=B) extended a "nowrap" state from its ancestor
+focusgroup and will use that value regardless of the presence of `wrap`.
+
+#### 6.5. Limiting linear focusgroup directionality
 
 In many cases, having multi-axis directional movement (both right arrow and down arrow linked to 
 the forward direction) is not desirable, such as when implementing a tablist, and it may not make
 sense for the up and down arrows to also move the focus left and right. Likewise, when moving up
 and down in a vertical menu, the author might wish to make use of the left and right arrow keys to
 provide behavior such as opening or closing sub-menus. In these situations, it makes sense to limit
-the focusgroup to one-axis traversal. The `horizontal` and `vertical` values provide this behavior. 
+the linear focusgroup to one-axis traversal.
+
+Note that the following only apply to linear focusgroup definitions (they have no effect on grid
+focusgroups).
+
+| HTML attribute value | CSS property & value | Explanation |
+|----------------------|----------------------|-------------|
+| focusgroup="horizontal" | focus&#8209;group&#8209;direction:&nbsp;horizontal | The focusgroup items will respond to forward and backward movement only with the "horizontal" arrow keys (left and right). |
+| focusgroup="vertical" | focus&#8209;group&#8209;direction:&nbsp;vertical | The focusgroup items will respond to forward and backward movement only with the "vertical" arrow keys (up and down). |
+| focusgroup="" (unspecified) | focus&#8209;group&#8209;direction:&nbsp;both | The focusgroup items will respond to forward and backward movement with both directions (horizontal and vertical). The default/initial value. |
 
 Example 8:
 ```html
-<tab-group role=tablist focusgroup="horizontal wrap"> 
+<style>
+  tab-group { focus-group: auto horizontal wrap; }
+</style>
+<!-- ... -->
+<tab-group role=tablist> 
   <a-tab role=tab tabindex=0>…</a-tab> 
   <a-tab role=tab tabindex=-1>…</a-tab> 
   <a-tab role=tab tabindex=-1>…</a-tab> 
@@ -399,6 +433,7 @@ same time on one focusgroup is not allowed:
 
 Example 9:
 ```html
+<!-- This is an example of what NOT TO DO -->
 <radiobutton-group focusgroup="horizontal vertical wrap"> 
   This focusgroup configuration is an error--neither constraint will be applied (which is actually 
   what the author intended).

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -697,11 +697,95 @@ the parent (and the wrapping value is also extended).
 
 ### 6.7. Opting-out
 
-TODO: describe how focusgroup items can opt-out
+Focusgroup definitions are assigned to an element in order to define the behavior for 
+their *child elements* which become focusgroup candidates. Because all *child elements*
+are focusgroup candidates, any child element that is (or becomes) focusable will
+automatically become a focusgroup item belonging to it's parent's focusgroup.
+
+What if an element should be focusable, exists as a child of an element with a focusgroup
+definition (because some of its other focusable siblings *should* belong to the focusgroup), 
+but does not want to participate in the focusgroup?
+
+Individual focusgroup candidates have the option of "opting-out" of participation in any
+focusgroup. Opting-out is a local focusgroup item decision (it should not be managed at the
+focusgroup definition attached to the parent element). In order for a focusgroup item to
+opt-out, a new (local) mechanism is needed.
+
+In this proposal, there is no way for a focusgroup item to opt-out using HTML alone (a 
+proposal would likely require a new attribute with different focusgroup semantics, and
+this opt-out scenario is considered an edge-case).
+
+To opt-out, a CSS property is used, which applies only to focusgroup candidates (not
+focusgroup definitions):
+
+| CSS property & value | Explanation |
+|----------------------|-------------|
+| focus&#8209;group&#8209;item:&nbsp;none | This focusgroup item will not participate in **any** focusgroup. (`none` is the initial value when there is no focusgroup definition on a parent element; `auto` is the initial value when there is a parent focusgropu definition.)  |
+
+Example 19:
+```html
+<style>
+  #container { focus-group: auto; }
+  .optout { focus-group-item: none; }
+</style>
+<!-- ... -->
+<control-row id=container>
+  <options-widget class=optout> ... </options-widget>
+  <action-button>...</action-button>
+  <action-button>...</action-button>
+  <action-button>...</action-button>
+  <action-button>...</action-button>
+</control-row>
+```
 
 ### 6.8. Multiple focusgroups among siblings
 
-TODO: describe how this works in CSS
+Similar to how some focusgroup candidates may want to opt-out (see prior section), other
+focusgroup candidates among a set of sibling elements may desire to participate in a 
+separate focusgroup from their other siblings.
+
+We elect to only provide this advanced scenario with CSS. Using `focus-group-item`, a 
+focusgroup candidate can specify the custom identifier of a matching parent focusgroup
+definition it would like to belong to (assuming it is focusable).
+
+CSS quite easily allows multiple focusgroup definitions to be applied to a single 
+container element via custom identifiers (this would be less elegant with HTML 
+attributes). The name `auto` (and the grid focusgroup names) are reserved, but other
+values are treated as custom identifiers and define new focusgroup definitions that
+focusgroup candidates can opt-into.
+
+**Note**: a focusgroup candidate can **only** be in one focusgroup at a time, and the 
+focusgroup it belongs to is the one specified by its `focus-group-item` value.
+
+| CSS property & value | Explanation |
+|----------------------|-------------|
+| focus&#8209;group&#8209;name:&nbsp;<custom&nbsp;ident> | Gives the focusgroup a custom identifiers. Only focusgroup candidates that opt-in to this named identifier will belong to this focusgroup. |
+| focus&#8209;group&#8209;item:&nbsp;<custom&nbsp;ident> | Declares this focusgroup candidates intention to belong to a focusgroup definition with the given identifier. |
+| focus&#8209;group&#8209;name, focus&#8209;group&#8209;direction, and focus&#8209;group&#8209;wrap | Each allows comma-separated list to accomodate multiple definitions. |
+
+The following example shows one parent element that has two focusgroups defined, and 
+opts half of the children into one and half into the other.
+
+Example 20:
+```html
+<style>
+  tabs { 
+    focus-group-name: redtab, bluetab;
+    focus-group-direction: horizontal, horizontal;
+  }
+  .redtab { focus-group-item: redtab; }
+  .bluetab { focus-group-item: bluetab; }
+</style>
+<!-- ... -->
+<tabs focusgroup>
+  <tab class=redtab>...</tab>
+  <tab class=redtab>...</tab>
+  <tab class=redtab>...</tab>
+  <tab class=bluetab>...</tab>
+  <tab class=bluetab>...</tab>
+  <tab class=bluetab>...</tab>
+</tab>
+```
 
 ### 6.9. grid focusgroups
 

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -1127,3 +1127,9 @@ increments), as well as the home/end keys to jump to the beginning and end of gr
 It might also be interesting to add support for typeahead scenarios (though what values to
 look for when building an index would need to be worked out, and may ultimately prove to be
 too complicated).
+
+## Acknowledgments
+
+Special thanks to those have have reviewed, commented on, filed issues, and talked with us
+offline about focusgroup. Your insight and ideas and contributions have helped dramatically
+improve this proposal.

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -125,7 +125,9 @@ focus tracking are unchanged with this proposal.
 ## 6. Focusgroup Concepts
 
 A focusgroup is a group of elements that are related by arrow-key navigation and for which the 
-platform provides the arrow key navigation behavior by default (no JavaScript event handlers needed!)
+platform provides the arrow key navigation behavior by default (no JavaScript event handlers needed)!
+Navigation is provided according to order or structure of the DOM (not how the content is presented 
+in a user interface).
 
 This document describes two kinds of focusgroups: **linear focusgroups** and **grid focusgroups**.
 Linear focusgroups provide arrow key navigation among a *list* of elements. Grid focusgroups provide 
@@ -278,10 +280,29 @@ to be used to "exit" these trapping elements).
 
 ### 6.3. Configuring and customizing the focusgroup
 
-#### 6.3.1. 'wrap' - Wrapping focus
+#### 6.3.1. Wrapping behaviors
 
-By default, the focusgroup only provides linear traversal of the items in the group. When focus reaches
-a boundary, it stops. To enable wrap-around focus behavior, add the `wrap` token to the attribute.
+By default, focusgroup traversal with arrow keys ends at boundaries of the focus group (the start and
+end of a linear focusgroup, and the start and end of both rows and columns in a grid focusgroup). The 
+following focusgroup definition values can configure this:
+
+| HTML attribute value | CSS property & value | Explanation |
+|----------------------|----------------------|-------------|
+| focusgroup="wrap" | focus&#8209;group&#8209;wrap:&nbsp;wrap | **linear focusgroup**: causes movement beyond the ends of the focusgroup to wrap around to the other side; **grid focusgroup**: causes focus movement at the ends of the rows/columns to wrap around to the opposite side of the same rows/columns |
+| focusgroup="nowrap" | focus&#8209;group&#8209;wrap:&nbsp;nowrap | Disables any kind of wrapping (the initial/default value) |
+
+The following are only applicable to grid focusgroups:
+
+| HTML attribute value | CSS property & value | Explanation |
+|----------------------|----------------------|-------------|
+| focusgroup="row-wrap" | focus&#8209;group&#8209;wrap:&nbsp;row&#8209;wrap | Rows wrap around, but column wrapping [and flowing as described below] is disabled. |
+| focusgroup="col-wrap" | focus&#8209;group&#8209;wrap:&nbsp;col&#8209;wrap | Columns wrap around, but row wrapping [and flowing as described below] is disabled. |
+| focusgroup="flow" | focus&#8209;group&#8209;wrap:&nbsp;flow | Movement past the end of a row wraps the focus to the beginning of **the next row**. Movement past the beginning of a row wraps focus back to the end of **the prior row**. Same for columns. The last row/column wraps to the first row/column and vice versa. |
+| focusgroup="row-flow" | focus&#8209;group&#8209;wrap:&nbsp;row&#8209;flow | Rows "flow" from row ends to the next/prior row as described above, but column flowing/wrapping is disabled. |
+| focusgroup="col-flow" | focus&#8209;group&#8209;wrap:&nbsp;col&#8209;flow | Columns "flow" from column ends to the next/prior column as described above, but row flowing/wrapping is disabled. |
+
+No option is provided for the hybrid condition of row wrap + column flow behavior (or vice-versa) in the 
+same grid. If this combination of behavior is needed, we want to hear this feedback.
 
 #### 6.3.2. 'extend' - Extending the focusgroup
 

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -1,4 +1,5 @@
-# HTML focusgroup attribute
+# focusgroup for HTML and CSS
+> Now with 100% more Style[sheet support]!
 
 Authors: [Travis Leithead](https://github.com/travisleithead),
          [David Zearing](https://github.com/dzearing),
@@ -13,10 +14,6 @@ most current standards venue and content location of future work and discussions
 * This document status: **Active**
 * Expected venue: [WHATWG HTML Workstream](https://whatwg.org/workstreams#:~:text=html)
 * **Current version: this document**
-
-**⭐New: A video recording of 
-[a presentation of this explainer to the W3C Open UI community group](https://us02web.zoom.us/rec/play/M9CQws3fPYB6vzKjvjJi6uVgYbzHKZ2L5pWpZ-A_VNUa8SbPiqsZFoGX4TmbgClfIo2RHZdeHxoi3gyN.BJWX3lSoah5ddYDW?continueMode=true&_x_zm_rtaid=vgoo4d78TTmnS6SlqvSKQw.1631896465490.797a543ba5ef0034680f19392aa6a088&_x_zm_rhtaid=706)
-is now available.**
 
 ## 1. Introduction
 

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -821,9 +821,10 @@ like a grid and that the structure makes semantic sense in two dimensions (and n
 just for a particular layout or presentation).
 
 Tabular data can be structured using column-major or row-major organization. Given
-that ARIA attributes for grids (role=grid, role=row, role=gridcell) only exist for
-row-major grid types, this proposal does **not define** grid focusgroup organization
-for column-major data structures (and assumes row-major data structures throughout).
+that HTML tables and ARIA attributes for grids (role=grid, role=row, role=gridcell)
+only exist for row-major grid types, this proposal does **not define** grid focusgroup
+organization for column-major data structures (and assumes row-major data structures 
+throughout).
 
 #### 6.9.2. Grid isolation
 

--- a/Focusgroup/explainer.md
+++ b/Focusgroup/explainer.md
@@ -115,7 +115,7 @@ focus tracking are unchanged with this proposal.
 5. (Extend same direction) Focusgroups can be nested to provide arrow navigation into multiple 
     composed widgets (such as lists within lists).
 6. (Extend opposite direction) Focusgroups can be nested to provide arrow navigation into composed
-    widgets with orthogonal navigation semanantics (such as horizontal-inside-vertical menus).
+    widgets with orthogonal navigation semantics (such as horizontal-inside-vertical menus).
 7. (Multiple focusgroups) Multiple focusgroups can be established on a single element (advanced CSS 
     scenario).
 8. (Opt-out) Individual elements can opt-out of focusgroup participation (advanced CSS scenario)
@@ -310,7 +310,7 @@ assign a focusgroup candidate state to a descendant element (explained later). T
 `extend`. A linear focusgroup definition can declare that it intends to `extend` an ancestor linear 
 focusgroup. If there is an ancestor linear focusgroup of the same name, the extending focusgroup
 becomes an extension of that ancestor's focusgroup. Extending a linear focusgroup is also an
-opportunity to change the directionality (and, conditionally, the wrappping) of the newly extended
+opportunity to change the directionality (and, conditionally, the wrapping) of the newly extended
 focusgroup candidates (as described later).
 
 Using `extend` in a focusgroup definition is only valid for linear focusgroups. Grid focusgroups 
@@ -598,7 +598,7 @@ Example 14:
 The above is a case where the focusgroups make an extended linear focusgroup in the horizontal
 direction (`wrap` state cannot be changed by the child for the horizontal direction), and a 
 descender/ascender relationship in the vertical direction (it's one-way: from the `<span>` to the
-`<div>` not vice-versa). But because the `<span>`'s focusgroup defintion does not support the 
+`<div>` not vice-versa). But because the `<span>`'s focusgroup definition does not support the 
 vertical direction, wrapping state is not extended from the parent. Conversely:
 
 Example 15:
@@ -725,7 +725,7 @@ focusgroup definitions):
 
 | CSS property & value | Explanation |
 |----------------------|-------------|
-| focus&#8209;group&#8209;item:&nbsp;auto | Opt-in to a focusgroup: this element becomes a focusgroup candidate for the **nearest ancestor** that defines a linear focusgroup matching `auto`. The element will "search" its parent nodes looking for a matching focusgroup definition and will become an "extension" of that group (i.e., similar to using `extend`, but without the opportunity to re-establish a new focusgroup defintion) |
+| focus&#8209;group&#8209;item:&nbsp;auto | Opt-in to a focusgroup: this element becomes a focusgroup candidate for the **nearest ancestor** that defines a linear focusgroup matching `auto`. The element will "search" its parent nodes looking for a matching focusgroup definition and will become an "extension" of that group (i.e., similar to using `extend`, but without the opportunity to re-establish a new focusgroup definition) |
 | focus&#8209;group&#8209;item:&nbsp;none | Opt-out of a focusgroup: this element will not participate in **any** focusgroup. (`none` is the initial value when there is no focusgroup definition on a parent element; `auto` is the initial value when there is a parent focusgroup definition.) |
 
 In the following example, the `options-widget` opts-out of participation in the focusgroup.
@@ -791,7 +791,7 @@ focusgroup it belongs to is the one specified by its `focus-group-item` value.
 |----------------------|-------------|
 | focus&#8209;group&#8209;name:&nbsp;<custom&nbsp;ident> | Gives the focusgroup a custom identifiers. Only focusgroup candidates that opt-in to this named identifier will belong to this focusgroup. |
 | focus&#8209;group&#8209;item:&nbsp;<custom&nbsp;ident> | Declares this focusgroup candidate's intention to belong to a focusgroup definition with the given identifier. If there is no matching focusgroup definition with this name in its ancestry, then this is an error and this item will revert to focus-group-item: `none` (or `auto` if it is a child of an element defining a linear focusgroup. |
-| focus&#8209;group&#8209;name, focus&#8209;group&#8209;direction, and focus&#8209;group&#8209;wrap | Each allows comma-separated list to accomodate multiple definitions. |
+| focus&#8209;group&#8209;name, focus&#8209;group&#8209;direction, and focus&#8209;group&#8209;wrap | Each allows comma-separated list to accommodate multiple definitions. |
 
 The following example shows one parent element that has two focusgroups defined, and 
 opts half of the children into one and half into the other.
@@ -860,12 +860,12 @@ throughout).
 
 As noted previously the `extend` value is not applicable to grid focusgroups, and 
 grid focusgroups cannot be combined with linear focusgroups. While it is obviously
-possible to create linear focusgroups inside of a grid cell datastructure, and 
+possible to create linear focusgroups inside of a grid cell data structure, and 
 vice-versa (a grid as a value of a list), this proposal does not allow these different
 focusgroup types to be connected automatically. Some additional scripting may be
 necessary to add explicit "cell enter/exit" behavior (or just use the Tab key).
 
-#### 6.9.2. Setting up a grid focusgroup
+#### 6.9.3. Setting up a grid focusgroup
 
 Grid focusgroups can be created "automatically" or manually. HTML only supports
 the "automatic" grid, while CSS can be used to do the same or to manually
@@ -889,7 +889,7 @@ Elements with the `grid` focusgroup definition on the root element of the struct
 grid become automatic grid focusgroups. The implementation must attempt to validate
 the structure of the grid to ensure it has appropriate row and cell structures. In the 
 event that the implementation cannot automatically determine the grid structure, then
-the defintion is ignored (i.e., there is no fallback to a linear grid).
+the definition is ignored (i.e., there is no fallback to a linear grid).
 
 | HTML attribute value | CSS property & value | Explanation |
 |----------------------|----------------------|-------------|
@@ -911,7 +911,7 @@ arrow keys in this grid focusgroup will navigate between cells in the table, and
 up/down arrow keys will compute the new target based on the DOM position of the
 current focusgroup candidate cell in relation to the focusgroup candidate row. 
 
-#### 6.9.3. Manual grids: row and cell connections
+#### 6.9.4. Manual grids: row and cell connections
 
 A manual grid is declared in a focusgroup definition with the name `manual-grid`.
 With a manual grid, the rows and cells must be explicitly indicated using 
@@ -998,14 +998,14 @@ Example 24:
   </div>
 ```
 
-#### 6.9.4. Empty Cell data 
+#### 6.9.5. Empty Cell data 
 
 Like linear focusgroups, focus is only set on elements that are focusable.
 The arrow key navigation algorithms look for grid focusgroup cells in the
 direction the arrow was pressed. Non-focusable grid focusgroup candidate cells
 are passed over in the search.
 
-#### 6.9.5. Non-uniform cells
+#### 6.9.6. Non-uniform cells
 
 It is entirely possible to have rows with non-uniform numbers of cells. In these
 cases, focusgroup navigation behaviors may not work as visibly desired. Algorithms
@@ -1074,7 +1074,7 @@ differ in some significant ways:
         zoom level), authors must likely provide dynamic run-time updates to `nav-*` properties 
         in order to keep top/left/bottom/right navigation logical per the current layout.
     * Related to the previous point, it can be easy to make logical errors in navigation 
-        sequences when targetting specific directions. This can lead to directions that don't
+        sequences when targeting specific directions. This can lead to directions that don't
         match the property names (e.g., `nav-left` actually navigates up or right) while also
         opening up the possibility of unidirectional navigation (e.g., after navigating right,
         the user can't go "back" to the left due to missing or erroneous selectors).
@@ -1145,7 +1145,7 @@ the element's preexisting built-in behavior in favor of the new generic behavior
 Implementation experience and additional community feedback will be necessary to land 
 a reasonable plan for this case.
 
-### 9.1. Additional Keyboard support 
+### 10.1. Additional Keyboard support 
 
 In addition to arrow keys, the focusgroup should also enable other navigation keys such as
 pageup/down for paginated movement (TBD on how this could be calculated and in what 
@@ -1157,6 +1157,6 @@ too complicated).
 
 ## Acknowledgments
 
-Special thanks to those have have reviewed, commented on, filed issues, and talked with us
+Special thanks to those who have reviewed, commented on, filed issues, and talked with us
 offline about focusgroup. Your insight and ideas and contributions have helped dramatically
 improve this proposal.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ we move them into the [Alumni section](#alumni-) below.
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Custom%20Control%20UI">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/Custom%20Control%20UI?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=dandclark&labels=Custom+Control+UI&template=custom-control-ui.md&title=%5BEnabling+Custom+Control+UI%5D+%3CTITLE+HERE%3E)
-* [`focusgroup` attribute](Focusgroup/explainer.md) ([video overview](https://us02web.zoom.us/rec/play/M9CQws3fPYB6vzKjvjJi6uVgYbzHKZ2L5pWpZ-A_VNUa8SbPiqsZFoGX4TmbgClfIo2RHZdeHxoi3gyN.BJWX3lSoah5ddYDW?continueMode=true&_x_zm_rtaid=vgoo4d78TTmnS6SlqvSKQw.1631896465490.797a543ba5ef0034680f19392aa6a088&_x_zm_rhtaid=706)) |
+* [focusgroup for HTML and CSS](Focusgroup/explainer.md) ([video overview](https://us02web.zoom.us/rec/play/M9CQws3fPYB6vzKjvjJi6uVgYbzHKZ2L5pWpZ-A_VNUa8SbPiqsZFoGX4TmbgClfIo2RHZdeHxoi3gyN.BJWX3lSoah5ddYDW?continueMode=true&_x_zm_rtaid=vgoo4d78TTmnS6SlqvSKQw.1631896465490.797a543ba5ef0034680f19392aa6a088&_x_zm_rhtaid=706)) |
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/focusgroup">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/focusgroup?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=travisleithead&labels=focusgroup&template=focusgroup.md&title=%5Bfocusgroup%5D+%3CTITLE+HERE%3E)


### PR DESCRIPTION
This update focuses on several shortcomings identified with the current proposal:

1. Focusgroup attribute explosion. The focusgroup attribute has a scope of the annotated element's immediate children. In order to accommodate sometimes deep-nested subtrees, the current design requires that the focusgroup attribute be placed at each level of the subtree hierarchy and "extend" the previous focusgroup in order to continue the logical focusgroup down into that immediate next step of children. For deeply nested subtrees this introduces a lot of focusgroup attributes that just act as a chain to extend the focusgroup down to where it needs to apply.

2. Opting-out elements from participation in a focus group. All eligible children of a focusgroup are automatically included in that focusgroup. The only way to exclude elements from the focusgroup are to make them ineligible, which means to make them not keyboard focusable. We recognize that there may be cases for child elements of a focusgroup to maintain their focusable nature, yet opt-out of belonging to the parent focusgroup. Furthermore, a scenario identified in issue #532 is similar—rather than opting out, some children under a focus group may want to participate in a completely separate focusgroup. For example, two logical focusgroups that just happen to have the same parent. This scenario isn't possible with the current design, but could be an advanced scenario important to support.

3. CSS property mappings. It seems important to provide a CSS syntax to opt-in to focusgroup behavior through CSS alone. As CSS Toggles are likely a necessary feature to complete the 'state' storage of a declarative-only "roving tabindex" solution, and CSS Toggles are CSS only; having all the control points available for both focusgroup and Toggles in CSS is a convenience worth specifying at this point

4. Grid declarations for HTML were a little too complex for simple use cases. We simplified grid scenarios into simple cases that can use html semantics to figure it out, and manual-grids where everything must be explicitly decorated and left that latter scenario to CSS which can manage it with ease.