### PR TITLE
Move proposed changes to Range interface

### DIFF
--- a/RangeInnerText/explainer.md
+++ b/RangeInnerText/explainer.md
@@ -108,14 +108,14 @@ async function initiateSpellcheck(editableRegion) {
 
     // `results` is an array of misspelled word + code unit offsets.
     results.forEach((result) => {
-      let misspelling = new StaticRange(range);
+      let misspelling = new Range(range);
       misspelling.adjust("start", result.offset);
       misspelling.collapse(/*toStart*/ true);
       misspelling.adjust("end", result.text.length);
 
       // Add misspelling range to highlight map so that the
       // squiggles are drawn underneath via Highlight API.
-      CSS.highlights.set("misspellings", new Highlight(mispelling));
+      CSS.highlights.set("misspellings", new Highlight(new StaticRange(mispelling)));
     });
   });
 }

--- a/RangeInnerText/explainer.md
+++ b/RangeInnerText/explainer.md
@@ -128,7 +128,7 @@ enum Endpoint {
     "end"
 }
 
-partial interface AbstractRange {
+partial interface Range {
     readonly DOMString innerText;
     void adjust(Endpoint endpoint, long codeunits);
 }


### PR DESCRIPTION
AbstractRange is for readonly access (and Range contains toString() behavior today as well). These proposed additions belong on Range.