### PR TITLE
[PerformanceNavigationTiming User Launch] Fixing 'New Issue' link

### DIFF
--- a/PerformanceNavigationTiming for User Agent Launch/explainer.md
+++ b/PerformanceNavigationTiming for User Agent Launch/explainer.md
@@ -121,15 +121,10 @@ An analysis of fingerprinting capability provided by this surface suggests fairl
 
 No other meaningful privacy concerns are anticipated, but we welcome community feedback.
 
-## Alternative Solutions
-
-TODO: Discuss alternative designs that were considered (or may be explored in future iterations) with pros/cons.
-
 ## Open Questions
-
 
 ## Conclusion
 As outlined, it can be frustrating for application developers to identify and root-cause performance issues when load times that are influenced by other environmental factors like resource contention during a user agent launch. By modifying the `PerformanceNavigationTiming` API, web applications developers can have better insight into the conditions of their application's performance and remove noise in diagnosing performance metrics which will benefit the web apps ecosystem.
 
 ---
-[Related issues](https://github.com/MicrosoftEdge/MSEdgeExplainers-private/labels/Performance) | [Open a new issue](https://github.com/MicrosoftEdge/MSEdgeExplainers-private/issues/new?title=%5BPerformance%20Navigation%20Timing%5D)
+[Related issues](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Performance) | [Open a new issue](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=dylank%2C+hemingzh&labels=Perf+timing+during+browser+start&template=performance-timing-during-browser-start.md&title=%5BPerf+Timing+during+launch%5D+%3CTITLE+HERE%3E)

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ we move them into the [Alumni section](#alumni-) below.
 
 ### Performance
 
-* [performance timings during launch](PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md) | 
+* [PerformanceNavigationTiming User Agent Launch](PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md) | 
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/Perf%20timing%20during%20browser%20start">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/Perf%20timing%20during%20browser%20start?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=dylank%2C+hemingzh&labels=Perf+timing+during+browser+start&template=performance-timing-during-browser-start.md&title=%5BPerf+Timing+during+launch%5D+%3CTITLE+HERE%3E)
-* [PerformanceNavigationTiming changes for protocol launch](PerformanceNavigationTiming%20changes%20for%20protocol%20launch/explainer.md) | 
+* [PerformanceNavigationTiming Protocol Launch](PerformanceNavigationTiming%20changes%20for%20protocol%20launch/explainer.md) | 
     <a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/PerformanceNavigationTiming%20for%20Protocol%20Launch">
     ![GitHub issues by-label](https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/PerformanceNavigationTiming%20for%20Protocol%20Launch?label=issues)</a> |
     [New issue...](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?assignees=atulkatti&labels=PerformanceNavigationTiming+for+Protocol+Launch&template=performancenavigationtiming-protocol-launch-timing-information.md&title=)


### PR DESCRIPTION
'New Issue' link in public explainer was pointing to 'New Issue' in private repository. Fixed this and adjusted titles in the README to reduce confusion between two similar Explainers.