### PR TITLE
Detect contenteditable elements

### DIFF
--- a/Focusgroup/focusgroup_polyfill.js
+++ b/Focusgroup/focusgroup_polyfill.js
@@ -238,7 +238,7 @@ class FocusGroupManager {
       return true;
     if ( node.nodeName == "TEXTAREA" && !node.hasAttribute( "disabled" ) )
       return true;
-    if ( node.hasAttribute( "contenteditable" ) && node.getAttribute("contenteditable") == "true" )
+    if ( node.contentEditable === 'true' )
       return true;
     if ( node.nodeName == "IFRAME" )
       return true;


### PR DESCRIPTION
An element can have the `contenteditable` value "true" but also "" (emty string) or to be editable.
See: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable

But anyway, an easier way to see if it's a contenteditable-root element is to use the property `node.contentEditable`, which has wide support.
See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contentEditable