### PR TITLE
"FocusGroup polyfill" initialize at the right time

### DIFF
--- a/Focusgroup/focusgroup_polyfill.js
+++ b/Focusgroup/focusgroup_polyfill.js
@@ -276,9 +276,9 @@ function OneTimeInit() {
 
 const focusgroupManagers = new WeakMap();
 
-if ( document.readyState != "complete" ) {
-  document.addEventListener('DOMContentLoaded', OneTimeInit, { once: true } );
+if ( document.readyState != "loading" ) {
+  OneTimeInit(); // run right now.
 }
 else {
-  OneTimeInit(); // run right now.
+  document.addEventListener('DOMContentLoaded', OneTimeInit, { once: true } );
 }


### PR DESCRIPTION
There are 3 readyStates in this order:

1. loading 
|
|
  -> DOMContentLoaded fires
2. interactive
|
| < - script executes, `!complete ? addEventListener(...) : OneTimeInit()` // addEventListener wins
|
3. complete

If the script is executed between `interactive` and `complete`,  `OneTimeInit` does not run right now and the "DOMContentLoaded" listener will never fire.