### PR TITLE
Add Upstream Trials to Origin Trials page

### DIFF
--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -3,21 +3,25 @@
         {
             "label": "Web Haptics API",
             "expiration": "2023-12-31",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
             "issue": "WebHaptics",
             "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/HapticsDevice/explainer.md"
         },{
             "label": "Digital Goods API",
             "expiration": "2023-12-31",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
             "explainer": "#"
         },{
             "label": "SystemEntropy in PerformanceNavigationTiming",
             "expiration": "2023-11-1",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
             "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md",
             "issue": "PerformanceNavigationTimingSystemEntropy ",
             "flag": "MsUserAgentLaunchNavType"
         },{
             "label": "Unsanitized HTML for Async Clipboard API",
             "expiration": "2024-02-29",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
             "explainer": "https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-unsanitized/explainer.md",
             "flag": "EdgeClipboardUnsanitizedContent"
         }

--- a/origin-trials/index.html
+++ b/origin-trials/index.html
@@ -14,7 +14,10 @@
         </header>
         <main>
             <h2>Active Origin Trials</h2>
-            <section id="active-trials-section"></section>
+            <section id="edge-active-trials-section"></section>
+            <details><summary>Active Chrome Origin Trials (Also available in Edge)</summary>
+                <section id="chrome-active-trials-section"></section>
+            </details>
             <hr>
             <section id="guide-section">
                 <h2>Getting Started</h2>

--- a/origin-trials/script.js
+++ b/origin-trials/script.js
@@ -7,11 +7,11 @@ if (document.readyState != 'loading') {
 async function onload() {
   let edgeSection = document.querySelector("#edge-active-trials-section");
   let chromeSection = document.querySelector("#chrome-active-trials-section");
-  await populateActiveTrialList('downstream-trials.json', edgeSection);
-  await populateActiveTrialList('upstream-trials.json', chromeSection);
+  await populateActiveTrialList('downstream-trials.json', edgeSection, /*isUpstream=*/false);
+  await populateActiveTrialList('upstream-trials.json', chromeSection, /*isUpstream=*/true);
 }
 
-async function populateActiveTrialList(trialsFile, section) {
+async function populateActiveTrialList(trialsFile, section, isUpstream) {
 
     let trials = await fetch(trialsFile)
         .then( stream => stream.json() )
@@ -32,6 +32,7 @@ async function populateActiveTrialList(trialsFile, section) {
         card.setAttribute("expires", expires);
         card.setAttribute("explainer", explainer);
         card.setAttribute("repo", repo);
+        card.setAttribute("upstream", isUpstream);
 
         if (feedbackLink != undefined) {
             card.setAttribute("feedbackLink", feedbackLink);

--- a/origin-trials/script.js
+++ b/origin-trials/script.js
@@ -5,31 +5,36 @@ if (document.readyState != 'loading') {
 }
 
 async function onload() {
-    await populateActiveTrialList();
+  let edgeSection = document.querySelector("#edge-active-trials-section");
+  let chromeSection = document.querySelector("#chrome-active-trials-section");
+  await populateActiveTrialList('downstream-trials.json', edgeSection);
+  await populateActiveTrialList('upstream-trials.json', chromeSection);
 }
 
-async function populateActiveTrialList() {
+async function populateActiveTrialList(trialsFile, section) {
 
-    let trials = await fetch('trials.json')
+    let trials = await fetch(trialsFile)
         .then( stream => stream.json() )
 
     let active = trials["active"];
 
-    let section = document.querySelector("#active-trials-section");
-
     active.forEach( trial  => {
-        let label       = trial["label"];
-        let expires     = trial["expiration"];
-        let explainer   = trial["explainer"];
-        let issue       = trial["issue"];
+        let label        = trial["label"];
+        let expires      = trial["expiration"];
+        let explainer    = trial["explainer"];
+        let repo         = trial["repo"];
+        let issue        = trial["issue"];
+        let feedbackLink = trial["feedbackLink"];
 
         let card = document.createElement("trial-card");
 
         card.setAttribute("label", label);
         card.setAttribute("expires", expires);
-        
-        if (explainer != undefined) {
-            card.setAttribute("explainer", explainer);
+        card.setAttribute("explainer", explainer);
+        card.setAttribute("repo", repo);
+
+        if (feedbackLink != undefined) {
+            card.setAttribute("feedbackLink", feedbackLink);
         }
 
         if (issue != undefined) {

--- a/origin-trials/styles.css
+++ b/origin-trials/styles.css
@@ -45,6 +45,19 @@ hr {
     width: 50%;
 }
 
+details {
+  margin-top: 1.5rem;
+}
+
+details section {
+  margin-top: 1.5rem;
+}
+
+summary {
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
 .note {
     background-color: rgba(28, 190, 28, 0.25);
     padding: 1rem 1.2rem;
@@ -56,8 +69,4 @@ hr {
     font-weight: 600;
     color: rgb(14, 80, 14);
     padding: 0rem 0rem 1rem 0rem
-}
-
-#active-trials-section {
-    margin: 4rem 0 0 0;
 }

--- a/origin-trials/trial-card.component.html
+++ b/origin-trials/trial-card.component.html
@@ -15,11 +15,16 @@
         font-weight: 600;
         flex-grow: 1;
         max-width: 50%;
+        overflow-wrap: break-word;
     }
 
-    .trial-card__explainer {
+    .trial-card__explainer, .trial-card__feedback {
         font-weight: 500;
         font-style: italic;
+    }
+
+    .trial-card__feedback {
+      display: none;
     }
 
     .trial-card__expires {
@@ -56,5 +61,6 @@
     <a class="trial-card__explainer">Explainer</a>
     <span class="trial-card__expires"></span>
     <a class="trial-card__issue-badge"></a>
+    <a class="trial-card__feedback">Feedback</a>
     <button class="trial-card__registration-button">Register</button>
 </div>

--- a/origin-trials/trial-card.component.js
+++ b/origin-trials/trial-card.component.js
@@ -17,33 +17,41 @@ function define(template) {
             this._explainer = this._shadow.querySelector('.trial-card__explainer');
             this._expires   = this._shadow.querySelector('.trial-card__expires');
             this._badge     = this._shadow.querySelector('.trial-card__issue-badge');
+            this._feedback  = this._shadow.querySelector('.trial-card__feedback');
             this._register  = this._shadow.querySelector('.trial-card__registration-button');
         }
 
         connectedCallback() {
             // Set initial values of elements based on attributes
-            let heading     = this.getAttribute("label");
-            let explainer   = this.getAttribute("explainer");
-            let expires     = this.getAttribute("expires");
-            let issue       = this.getAttribute("issue");
+            let heading      = this.getAttribute("label");
+            let explainer    = this.getAttribute("explainer");
+            let expires      = this.getAttribute("expires");
+            let repo         = this.getAttribute("repo");
+            let issue        = this.getAttribute("issue");
+            let feedbackLink = this.getAttribute("feedbackLink");
 
             this._heading.innerHTML = heading;
             this._expires.innerHTML = expires;
 
             this._explainer.setAttribute('href', explainer);
 
-            if (issue != null && issue.length > 0) {
-                this._badge.setAttribute('href', this.getIssueLink(issue));
+            if (feedbackLink != null) {
+                this._feedback.setAttribute('href', feedbackLink);
+
+                this._badge.style.display = "none";
+                this._feedback.style.display = "inline";
+            } else if (issue != null && issue.length > 0) {
+                this._badge.setAttribute('href', this.getIssueLink(repo, issue));
 
                 let img = document.createElement('img');
-                img.src = this.getIssueBadgeLink(issue);
+                img.src = this.getIssueBadgeLink(repo, issue);
 
                 this._badge.appendChild(img)
             } else {
-                this._badge.setAttribute('href', this.getGenericIssueLink(heading));
+                this._badge.setAttribute('href', this.getGenericIssueLink(repo, heading));
 
                 let img = document.createElement('img');
-                img.src = this.getIssueBadgeLink('OriginTrialFeedback');
+                img.src = this.getIssueBadgeLink(repo, 'OriginTrialFeedback');
 
                 this._badge.appendChild(img);
             }
@@ -55,20 +63,25 @@ function define(template) {
             console.log(`${name} ${previous} ${current}`);
         }
 
-        getIssueBadgeLink(tag) {
-            let encoded = encodeURI(tag);
-            return `https://img.shields.io/github/issues/MicrosoftEdge/MSEdgeExplainers/${encoded}?label=issues`;
+        getIssueBadgeLink(repo, tag) {
+            let encodedTag = encodeURI(tag);
+            return `https://img.shields.io/github/issues/${repo}/${encodedTag}?label=issues`;
         }
 
-        getIssueLink(tag) {
-            let encoded = encodeURI(tag);
+        getIssueLink(repo, tag) {
+            let encodedTag = encodeURI(tag);
             let label = tag.replace(' ', '+')
-            return `https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?labels=${label},OriginTrialFeedback&title=%5B${encoded}%5D+Feedback`
+            return `https://github.com/${repo}/issues/new?labels=${label},OriginTrialFeedback&title=%5B${encodedTag}%5D+Feedback`
         }
 
-        getGenericIssueLink(name) {
-            let encoded = encodeURI(name);
-            return `https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?labels=OriginTrialFeedback&title=%5B${encoded}%5D+Feedback`;
+        getGenericIssueLink(repo, name) {
+            if (repo === "MicrosoftEdge/MSEdgeExplainers") {
+                let encodedName = encodeURI(name);
+                return `https://github.com/${repo}/issues/new?labels=OriginTrialFeedback&title=%5B${encodedName}%5D+Feedback`;
+            } else {
+                return `https://github.com/${repo}/issues/new`;
+            }
+
         }
     }
 

--- a/origin-trials/trial-card.component.js
+++ b/origin-trials/trial-card.component.js
@@ -29,6 +29,7 @@ function define(template) {
             let repo         = this.getAttribute("repo");
             let issue        = this.getAttribute("issue");
             let feedbackLink = this.getAttribute("feedbackLink");
+            let isUpstream   = this.getAttribute("upstream"); 
 
             this._heading.innerHTML = heading;
             this._expires.innerHTML = expires;
@@ -44,14 +45,22 @@ function define(template) {
                 this._badge.setAttribute('href', this.getIssueLink(repo, issue));
 
                 let img = document.createElement('img');
-                img.src = this.getIssueBadgeLink(repo, issue);
+                if (isUpstream === "false") {
+                    img.src = this.getIssueBadgeLink(repo, issue);
+                } else {
+                    img.src = this.getIssueBadgeLink(repo, "");
+                }
 
                 this._badge.appendChild(img)
             } else {
                 this._badge.setAttribute('href', this.getGenericIssueLink(repo, heading));
 
                 let img = document.createElement('img');
-                img.src = this.getIssueBadgeLink(repo, 'OriginTrialFeedback');
+                if (isUpstream === "false") {
+                    img.src = this.getIssueBadgeLink(repo, 'OriginTrialFeedback');
+                } else {
+                    img.src = this.getIssueBadgeLink(repo, "");
+                }
 
                 this._badge.appendChild(img);
             }
@@ -64,8 +73,8 @@ function define(template) {
         }
 
         getIssueBadgeLink(repo, tag) {
-            let encodedTag = encodeURI(tag);
-            return `https://img.shields.io/github/issues/${repo}/${encodedTag}?label=issues`;
+            let encodedTag = tag.length > 0 ? `/${encodeURI(tag)}` : "";
+            return `https://img.shields.io/github/issues/${repo}${encodedTag}?label=issues`;
         }
 
         getIssueLink(repo, tag) {

--- a/origin-trials/upstream-trials.json
+++ b/origin-trials/upstream-trials.json
@@ -1,0 +1,224 @@
+{
+  "active": [
+    {
+        "label": "Back/forward cache NotRestoredReason API",
+        "expiration": "2023-08-08",
+        "repo": "rubberyuzu/bfcache-not-retored-reason",
+        "explainer": "https://github.com/rubberyuzu/bfcache-not-retored-reason/blob/main/NotRestoredReason.md"
+    },
+    {
+        "label": "Background Blur",
+        "expiration": "2023-11-02",
+        "repo": "w3c/mediacapture-extensions",
+        "explainer": "https://github.com/riju/backgroundBlur/blob/main/explainer.md"
+    },
+    {
+        "label": "CompressionDictionaryTransport",
+        "expiration": "2024-04-30",
+        "repo": "WICG/compression-dictionary-transport",
+        "explainer": "https://github.com/WICG/compression-dictionary-transport"
+    },
+    {
+        "label": "Compute Pressure",
+        "expiration": "2024-01-04",
+        "repo": "w3c/compute-pressure",
+        "explainer": "https://developer.chrome.com/docs/web-platform/compute-pressure/"
+    },
+    {
+        "label": "COOP: restrict-properties",
+        "expiration": "2024-02-06",
+        "feedbackLink": "https://docs.google.com/forms/d/1pJ-c7GlAYrwu95vIg9l1MDpBMhSDDTM4f6GXEIsAod0/edit?resourcekey=0-gDRkC9ScABNyMI9Y_VDA4w",
+        "explainer": "https://github.com/hemeryar/coi-with-popups"
+    },
+    {
+        "label": "Cross App and Web Attribution Measurement",
+        "expiration": "2024-02-06",
+        "repo": "WICG/attribution-reporting-api",
+        "explainer": "https://github.com/WICG/attribution-reporting-api/blob/main/app_to_web.md"
+    },
+    {
+        "label": "DisableThirdPartySessionStoragePartitioningAfterGeneralPartitioning",
+        "expiration": "2024-09-03",
+        "feedbackLink": "https://google.qualtrics.com/jfe/form/SV_dd2p0f6kgIwZ9D8",
+        "explainer": "https://github.com/wanderview/quota-storage-partitioning/blob/main/explainer.md"
+    },
+    {
+        "label": "DisableThirdPartyStoragePartitioning",
+        "expiration": "2024-09-03",
+        "feedbackLink": "https://google.qualtrics.com/jfe/form/SV_0qAfKX5h4w9BsVg",
+        "explainer": "https://github.com/wanderview/quota-storage-partitioning/blob/main/explainer.md"
+    },
+    {
+        "label": "Document Picture-in-Picture",
+        "expiration": "2023-09-07",
+        "repo": "WICG/document-picture-in-picture",
+        "explainer": "https://github.com/WICG/document-picture-in-picture"
+    },
+    {
+        "label": "EditContext",
+        "expiration": "2024-03-05",
+        "repo": "w3c/edit-context",
+        "explainer": "https://github.com/w3c/edit-context/blob/gh-pages/explainer.md"
+    },
+    {
+        "label": "Explicit Compile Hints with Magic Comments",
+        "expiration": "2023-11-02",
+        "feedbackLink": "https://google.qualtrics.com/jfe/form/SV_9SLyOGnTj2cwo0C",
+        "explainer": "https://docs.google.com/document/d/19xTAM4A75tz0xUq_velMzGA4JHEgXpyflUxXTcuNiyE/edit?usp=sharing"
+    },
+    {
+        "label": "FedCM IDP Sign-in Status API",
+        "expiration": "2024-02-06",
+        "repo": "fedidcg/FedCM",
+        "explainer": "https://github.com/fedidcg/FedCM/blob/main/proposals/idp-sign-in-status-api.md"
+    },
+    {
+        "label": "FedCM: Auto Re-Authentication API",
+        "expiration": "2023-08-08",
+        "repo": "fedidcg/FedCM",
+        "explainer": "https://github.com/fedidcg/FedCM/issues/429"
+    },
+    {
+        "label": "Long Animation Frames",
+        "expiration": "2024-03-05",
+        "repo": "w3c/longtasks",
+        "explainer": "https://github.com/w3c/longtasks/blob/main/loaf-explainer.md"
+    },
+    {
+        "label": "No-Vary-Search support in navigation prefetch cache",
+        "expiration": "2024-01-04",
+        "repo": "WICG/nav-speculation",
+        "explainer": "https://github.com/WICG/nav-speculation/blob/main/no-vary-search.md"
+    },
+    {
+        "label": "Page Unload Beacon",
+        "expiration": "2023-09-19",
+        "repo": "WICG/unload-beacon",
+        "explainer": "https://chromium.googlesource.com/chromium/src/+/main/docs/experiments/page-unload-beacon.md"
+    },
+    {
+        "label": "Payment handler minimal header UX",
+        "expiration": "2023-12-07",
+        "feedbackLink": "https://bugs.chromium.org/p/chromium/issues/entry?components=Blink%3EPayments",
+        "explainer": "https://groups.google.com/a/chromium.org/g/blink-dev/c/NQ-WLvfmPs8"
+    },
+    {
+        "label": "Privacy Sandbox Relevance and Measurement",
+        "expiration": "2023-09-19",
+        "feedbackLink": "https://developer.chrome.com/blog/privacy-sandbox-unified-origin-trial/#where-can-developers-give-feedback-and-get-support",
+        "explainer": "https://developer.chrome.com/blog/privacy-sandbox-unified-origin-trial/"
+    },
+    {
+        "label": "Private Network Access from non-secure contexts",
+        "expiration": "2024-02-06",
+        "repo": "WICG/private-network-access",
+        "explainer": "https://developer.chrome.com/blog/private-network-access-update/"
+    },
+    {
+        "label": "Reduce Accept-Language",
+        "expiration": "2023-08-08",
+        "repo": "Tanych/accept-language",
+        "explainer": "https://github.com/Tanych/accept-language"
+    },
+    {
+        "label": "RTCLegacyTrackStats",
+        "expiration": "2023-09-23",
+        "feedbackLink": "https://groups.google.com/a/chromium.org/g/blink-dev/c/NZVXsJQ7tV8",
+        "explainer": "https://w3c.github.io/webrtc-stats/"
+    },
+    {
+        "label": "RTCPeerConnection callback-based getStats() API",
+        "expiration": "2024-03-07",
+        "feedbackLink": "https://crbug.com/822696",
+        "explainer": "https://w3c.github.io/webrtc-stats/"
+    },
+    {
+        "label": "scheduler.yield()",
+        "expiration": "2024-01-04",
+        "repo": "wicg/scheduling-apis",
+        "explainer": "https://github.com/WICG/scheduling-apis/blob/main/implementation-status.md"
+    },
+    {
+        "label": "ServiceWorker static routing API",
+        "expiration": "2024-04-02",
+        "repo": "w3c/ServiceWorker",
+        "explainer": "https://github.com/yoshisatoyanagisawa/service-worker-static-routing-api"
+    },
+    {
+        "label": "ServiceWorkerBypassFetchHandlerForMainResources",
+        "expiration": "2023-09-23",
+        "repo": "w3c/ServiceWorker",
+        "explainer": "https://github.com/sisidovski/service-worker-bypass-fetch-handler-for-main-resource"
+    },
+    {
+        "label": "SharedArrayBuffers in non-isolated pages on Desktop platforms",
+        "expiration": "2024-03-07",
+        "feedbackLink": "https://bugs.chromium.org/p/chromium/issues/entry?components=Internals%3ESandbox%3ESiteIsolation",
+        "explainer": "https://developer.chrome.com/blog/enabling-shared-array-buffer/"
+    },
+    {
+        "label": "Speculation Rules - Document rules, response header, deliveryType",
+        "expiration": "2024-01-04",
+        "feedbackLink": "https://google.qualtrics.com/jfe/form/SV_4HePq4hnaw2MZUi",
+        "explainer": "https://github.com/WICG/nav-speculation/blob/main/chrome-2023q1-experiment-overview.md"
+    },
+    {
+        "label": "Storage Buckets API",
+        "expiration": "2024-01-04",
+        "repo": "WICG/storage-buckets",
+        "explainer": "https://developer.chrome.com/blog/storage-buckets/"
+    },
+    {
+        "label": "The Popover API",
+        "expiration": "2023-08-10",
+        "repo": "openui/open-ui",
+        "explainer": "https://open-ui.org/components/popup.research.explainer"
+    },
+    {
+        "label": "User-Agent Reduction Deprecation",
+        "expiration": "2023-09-23",
+        "repo": "w3ctag/design-reviews",
+        "explainer": "https://docs.google.com/document/d/1d-K43rzfDGxNM4H6Yzh5lV08KJwLsae06i4Q0A8snME"
+    },
+    {
+        "label": "Web App Dark Mode v2",
+        "expiration": "2023-08-08",
+        "repo": "WICG/manifest-incubations",
+        "explainer": "https://github.com/w3c/manifest/issues/1045"
+    },
+    {
+        "label": "WebAssembly Garbage Collection",
+        "expiration": "2023-11-02",
+        "feedbackLink": "https://bugs.chromium.org/p/v8/issues/list",
+        "explainer": "https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md"
+    },
+    {
+        "label": "WebGPU",
+        "expiration": "2023-08-10",
+        "repo": "gpuweb/gpuweb",
+        "explainer": "https://gpuweb.github.io/gpuweb/"
+    },
+    {
+        "label": "WebGPU WebCodecs integration",
+        "expiration": "2023-12-07",
+        "repo": "gpuweb/gpuweb",
+        "explainer": "https://gpuweb.github.io/gpuweb/explainer/#image-input"
+    },
+    {
+        "label": "WebSQL",
+        "expiration": "2024-05-28",
+        "feedbackLink": "https://crbug.com/695592",
+        "explainer": "https://developer.chrome.com/blog/deprecating-web-sql/"
+    },
+    {
+        "label": "X-Requested-With in WebView Deprecation",
+        "expiration": "2024-06-27",
+        "feedbackLink": "https://bugs.chromium.org/p/chromium/issues/entry?template=Webview+Bugs&labels=XRW-Deprecation",
+        "explainer": "https://docs.google.com/document/d/e/2PACX-1vSSTEsHVfTXwOW80Tqy4c5TW6wSnt9b8v7-ZWUF3ZqLDs03EatEuyPCqwaUaa2s0a7mFm3Wh61bgVoz/pub"
+    }
+  ],
+
+  "expired": [
+
+  ]
+}


### PR DESCRIPTION
Add Chrome Origin Trials to Edge Origin Trial page to indicate to users that these are also available in Edge.

The list of upstream OTs is long, so it's initially collapsed in a `<details>/<summary>`:

![image](https://github.com/MicrosoftEdge/MSEdgeExplainers/assets/1688716/b9849808-a65a-4675-9fba-61fbe01e3037)

When expanded it's stuctured similarly to the downstream list, with the only difference being that some entries have a Feedback link instead of a Issue Tracker badge, since some of the upstream trials aren't using GitHub for their feedback.

![image](https://github.com/MicrosoftEdge/MSEdgeExplainers/assets/1688716/1cce4929-b6e1-4639-937b-eb9d14fbf94b)

I'm a little uncertain about whether the badges should be used at all for upstream. Since we don't know the upstream repos' labeling schemes, we can't filter the badges to the issues opened for OTs, so they just show the full count of issues for the repo. If this is problematic we could just the generic "Feedback" link for all of them.