### PR TITLE
Ensures foreground and background meet WCAG 2 AA contrast ratio thresholds.

### DIFF
--- a/origin-trials/styles.css
+++ b/origin-trials/styles.css
@@ -15,7 +15,7 @@ body {
 
 header {
     background-color: #018273;
-    color: #f2f2f2;
+    color: #fefefe;
     display: flex;
     justify-content: center;
     height: 256px;


### PR DESCRIPTION
Updates the site header background to `#fefefe` from `#f2f2f2` 

![image](https://github.com/MicrosoftEdge/MSEdgeExplainers/assets/139378688/eeaae396-b3ca-4581-a528-e7c88bfa94ce)
Before:
The contrast between foreground and background colors does not meet WCAG 2 AA contrast ratio thresholds. i.e. color contrast ratio is 4.22:1

After:
Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds.