### PR TITLE
Update downstream-trials.json with deviceId addition.

### DIFF
--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -24,6 +24,13 @@
             "repo": "MicrosoftEdge/MSEdgeExplainers",
             "explainer": "https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-unsanitized/explainer.md",
             "flag": "EdgeClipboardUnsanitizedContent"
+        },{
+            "label": "PointerEvent.deviceId",
+            "expiration": "2024-02-14",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
+            "issue": "PointerEventDeviceId",
+            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PointerEventDeviceId/explainer.md",
+            "flag": "PointerEventDeviceId"
         }
     ],
 


### PR DESCRIPTION
Add an entry to the Edge origin trial dashboard for PointerEvent.deviceId.