### PR TITLE
[Side Panel] Explain why side-panel-only support is required

### DIFF
--- a/SidePanel/explainer.md
+++ b/SidePanel/explainer.md
@@ -6,6 +6,7 @@
 - [Hoch Hochkeppel](https://github.com/mhochk)
 - [Min Ren](https://github.com/renmin)
 - [Sohum Chatterjee](https://github.com/sohchatt)
+- [Xiaobin Cui](https://github.com/benjycui)
 
 ## Status of this Document
 
@@ -61,7 +62,9 @@ The side panel API is not intended to be used for:
 ## Use Cases
 
 The side panel API is intended to be used by web applications that want to
-provide a side-by-side experience. The browsers can promote the web application
+provide a side-by-side experience. By letting web applications detect being rendered and set side panel width, they can provide optimized user experiences in side panel, e.g., side panel might not provide omnibox and back/forward button, so web applications need to provide other way to navigate around.
+
+The browsers can promote the web application
 that supports the side panel API as a side-by-side web application. The browser
 can also provide a way for the user to pin the web application to the side panel
 so that the user can easily access the web application as a side-by-side web
@@ -83,19 +86,34 @@ via CSS or JavaScript.
 
 ```css
 @media all and (display-mode: side-panel) {
-  /* Styling for when in the side panel. */
+  /* Styling for when in the side panel only. */
 }
 ```
 
 ```js
 if (window.matchMedia('(display-mode: side-panel)').matches) {
-  // The web application is being displayed in the side panel.
+  // The web application is being specifically displayed in the side panel.
 }
 ```
 
 And when display mode is surfaced generically via request headers, it will
 be detectable there as well (see [crbug.com/1174843](https://crbug.com/1174843),
-[Display Mode Client Hint](https://github.com/WICG/manifest-incubations/blob/gh-pages/display_mode-client-hint.md))
+[Display Mode Client Hint](https://github.com/WICG/manifest-incubations/blob/gh-pages/display_mode-client-hint.md)). This means servers can redirect users to other sites then.
+
+> #### NOTE
+> Developers can set the default width of side panel with `side_panel.preferred_width`, this means that the width of side panel is arbitrary. But under most circumstances, side panel might be a narrow-width window. It is recommended to detect windows' width if these styles or behaviors are not side panel only.
+> 
+> ```css
+> @media all and (max-width: 380px) {
+>   /* Styling for when in narrow-width window. */
+> }
+> ```
+> 
+> ```js
+> if (window.matchMedia('(max-width: 380px)').matches) {
+>   // The web application is being displayed in narrow-width window.
+> }
+> ```
 
 #### Independent Declarations for Side Panel and OS Installation
 


### PR DESCRIPTION
1. explain why developers might need to provide side-panel-only content
2. encourage developers detect window's width if optimization is not side-panel-only.