### PR TITLE
Address issue #714 - update the same-origin install signatures

### DIFF
--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -17,7 +17,7 @@ Modern browsers have UX that enable users to *install* web content on their devi
 ## Goals
 
 * **Enable installation of web apps (same-origin).**
-* Complement `beforeinstallprompt` for platforms that do not prompt.
+* Complement `beforeinstallprompt` for platforms that do not prompt for installation of web content.
 * Allow the web app to report to the installation origin the outcome of the installation.
 * Enable UAs to supress potential installation-prompt spam.
 
@@ -62,21 +62,23 @@ The **`navigator.install()` method can overlap with some functionality of `befor
 
 On UAs that support prompting, the threshold for `navigator.install()` to resolve on same-origin installations uses the same checks that `onbeforeinstallprompt` currently has for prompting (if required by the UA). The promise doesn't resolve unless the *installability criteria* is met. *Note that the criteria defined by UAs varies and can be that there is NO criteria*.
 
-When called on the same domain, the **`install()` method will trigger/open the prompt for installation the same way that using `onbeforeinstallprompt` does right now for browser that prompts.** If the domain is not installable content, then the promise returns a `DOMException` of type 'AbortError'.
+When called on the same domain, the **`install()` method will trigger/open the prompt for installation the same way that using `onbeforeinstallprompt` does right now for browser that prompts.** If there is an error with the installation, then the promise returns a `DOMException` of type 'AbortError'. 
+
+*Any same-origin content can be installed even if it is **NOT** an application.*
 
 
 ## Proposed Solution
 
 ### The `navigator.install` method
 
-To install a web site/app, the site/app would use the promise-based method `navigator.install([<params>]);`. This method will:
+To install a web site/app, the site/app would use the promise-based method `navigator.install(manifest_id, [<params>]);`. This method will:
 
 * Resolve when an installation was completed.
     * The success value will be an object that contains:
      	*  `url`: url of the installed target.
 * Be rejected if the prompt is not shown or if the app installation did not complete. It'll reject with a [`DOMException`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) value of:
     * `AbortError`: The installation was not completed.
-    
+
  ```javascript
 /* simple example of using navigator.install */
 
@@ -94,15 +96,15 @@ const installApp = async () => {
 #### **Signatures of the `install` method (same-origin)**
 The same-origin part of the  Web Install API consists of the extension to the navigator interface with the install method. The install method can be used in several different ways. There is no difference in behaviour when this is called from a standalone window or a tab.
 
-1. `navigator.install()`: The method receives no parameters and tries to install the current origin as an app.
+1. `navigator.install([<params>])`: The method receives no parameters and tries to install the current origin as an app. Note that `manifest_id` *is required* for the installation and if the method is called without one it will use the *default* manifest id of the web content which resolves to the document url.
 
-2. `navigator.install(<params>)`: The method receives an object with parameters that it can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
+2. `navigator.install(manifest_id, [<params>])`: The method takes a manifest id and tries to install the current origin as an app. If the content being installed has a manifest file, this must match the value in the manifest file. If there is no manifest file present, it must match the document url. The call can also receive an object with parameters that it can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
 
 #### **Parameters**
 
 The `navigator.install` call can receive an object with a set of parameters that specify different installation behaviours for the app.
 
-* **referral-info**: this parameter takes the form of an object that can have arbitrary information desired to be captured at the time of installation. 
+* **referral-info**: this parameter takes the form of an object that can have arbitrary information desired to be captured at the time of installation.
 
 #### **Installing the web app**
 
@@ -131,7 +133,7 @@ relatedApps.forEach((app) => {
 ## Installability criteria
 In order for an application/site to be installed, it must comply with *installability criteria*. **This criteria is entirely up to the UA**, can *vary depending on the installation target*, and can be optional. 
 
-Modern browsers allow for different degrees of installation of different types of content, ranging from traditional web sites all the way up to Progressive Web Apps. **The core functionality of the API is that it allows to install *anything* initiated with a user action**.  
+Modern browsers allow for different degrees of installation of different types of content, ranging from traditional web sites all the way up to Progressive Web Apps. **The core functionality of the same-origin version of the API is that it allows to install *anything* initiated with a user action**.  
 
 A user agent might decide to have only the requirement of HTTPS to allow installation of a web site, or may need as well a manifest file and/or service worker to install a web app or might not require anything at all, allowing the user to install any content they wish.
 
@@ -141,9 +143,9 @@ A user agent might decide to have only the requirement of HTTPS to allow install
 
 * This API can only be invoked in a top-level navigable and be invoked from a [secure context](https://w3c.github.io/webappsec-secure-contexts/).
 
-* The biggest risk for the API is installation spamming. To minimize this behaviour, installing a PWA using the Web Install API requires a [user activation](https://html.spec.whatwg.org/multipage/interaction.html#activation-triggering-input-event).  
+* The biggest risk for the API is installation spamming. To minimize this behaviour, installing content using the Web Install API requires a [user activation](https://html.spec.whatwg.org/multipage/interaction.html#activation-triggering-input-event).  
 
-**For same-domain installs, the user gesture and the final installation confirmation (current default behaviour in the browser before installing an app) work together to minimize the risk of origins spamming the user for unrequested installations**. 
+**For same-domain installs, the user gesture and the final installation confirmation (current default behaviour in the browser before installing an app) work together to minimize the risk of origins spamming the user for unrequested installations**.
 
 ## Alternative Solutions
 


### PR DESCRIPTION
* adds requirement of 'manifest id' to the signatures of a same-origin installation.
* makes clear that same-origin installs work for any type of web content.


Resolves #714 
