### PR TITLE
issue # 715 - removes `mode` from the return object

### DIFF
--- a/WebInstall/explainer_cross_domain.md
+++ b/WebInstall/explainer_cross_domain.md
@@ -113,7 +113,7 @@ To install a web app, a web site would use the promise-based method `navigator.i
 
 * Resolve when an installation was completed.
     * The success value will be an object that contains:
-     	*  `mode`: string with the surface-hint where the app was installed.
+     	*  `manifest_id`: string with the computed `manifest_id` of the installed app.
 * Be rejected if the prompt is not shown or if the app installation did not complete. It'll reject with a [`DOMException`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) value of:
     * `AbortError`: The installation (prompt) was closed/cancelled.
 


### PR DESCRIPTION
* mode is no longer needed as this can be implied with a display-mode media query

* computed `manifest_id` is now returned in case the installation origin requires the id of the installed app

resolves #715