### PR TITLE
Extend Digital Goods API; Remove expired downstream trials.

### DIFF
--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -33,16 +33,16 @@
             "issue": "PointerEventDeviceId",
             "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PointerEventDeviceId/explainer.md",
             "flag": "PointerEventDeviceId"
-        }
-    ],
-
-    "expired": [
-        {
+        },{
             "label": "Web Haptics API",
             "expiration": "2023-12-31",
             "repo": "MicrosoftEdge/MSEdgeExplainers",
             "issue": "WebHaptics",
             "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/HapticsDevice/explainer.md"
         }
+    ],
+
+    "expired": [
+
     ]
 }

--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -9,16 +9,10 @@
             "flag": "msAcquisitionInfo"
         },{
             "label": "Digital Goods API",
-            "expiration": "2023-12-31",
+            "expiration": "2024-04-31",
             "repo": "MicrosoftEdge/MSEdgeExplainers",
-            "explainer": "#"
-        },{
-            "label": "SystemEntropy in PerformanceNavigationTiming",
-            "expiration": "2023-11-1",
-            "repo": "MicrosoftEdge/MSEdgeExplainers",
-            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md",
-            "issue": "PerformanceNavigationTimingSystemEntropy ",
-            "flag": "MsUserAgentLaunchNavType"
+            "explainer": "#",
+            "flag": "DigitalGoodsV2"
         },{
             "label": "Unsanitized HTML for Async Clipboard API",
             "expiration": "2024-02-29",
@@ -32,6 +26,17 @@
             "issue": "PointerEventDeviceId",
             "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PointerEventDeviceId/explainer.md",
             "flag": "PointerEventDeviceId"
+        }
+    ],
+
+    "expired": [
+        {
+            "label": "SystemEntropy in PerformanceNavigationTiming",
+            "expiration": "2023-11-1",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
+            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md",
+            "issue": "PerformanceNavigationTimingSystemEntropy ",
+            "flag": "MsUserAgentLaunchNavType"
         },{
             "label": "Web Haptics API",
             "expiration": "2023-12-31",
@@ -39,9 +44,5 @@
             "issue": "WebHaptics",
             "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/HapticsDevice/explainer.md"
         }
-    ],
-
-    "expired": [
-
     ]
 }

--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -14,6 +14,13 @@
             "explainer": "#",
             "flag": "DigitalGoodsV2"
         },{
+            "label": "SystemEntropy in PerformanceNavigationTiming",
+            "expiration": "2023-11-1",
+            "repo": "MicrosoftEdge/MSEdgeExplainers",
+            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md",
+            "issue": "PerformanceNavigationTimingSystemEntropy ",
+            "flag": "MsUserAgentLaunchNavType"
+        },{
             "label": "Unsanitized HTML for Async Clipboard API",
             "expiration": "2024-02-29",
             "repo": "MicrosoftEdge/MSEdgeExplainers",
@@ -31,13 +38,6 @@
 
     "expired": [
         {
-            "label": "SystemEntropy in PerformanceNavigationTiming",
-            "expiration": "2023-11-1",
-            "repo": "MicrosoftEdge/MSEdgeExplainers",
-            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PerformanceNavigationTiming%20for%20User%20Agent%20Launch/explainer.md",
-            "issue": "PerformanceNavigationTimingSystemEntropy ",
-            "flag": "MsUserAgentLaunchNavType"
-        },{
             "label": "Web Haptics API",
             "expiration": "2023-12-31",
             "repo": "MicrosoftEdge/MSEdgeExplainers",


### PR DESCRIPTION
Extends Digital Goods API until April 31st, 2024 and adds the OT flag name

Removes expired trials: 
- SystemEntropy in PerformanceNavigationTiming
- Web Haptics API