### PR TITLE
fixes `install_url` fallback value

### DIFF
--- a/WebInstall/explainer_cross_domain.md
+++ b/WebInstall/explainer_cross_domain.md
@@ -80,7 +80,7 @@ To install a web app, a web site would use the promise-based method `navigator.i
 #### **Signatures of the `install` method (cross-origin)**
 The cross-origin part of the Web Install API consists of the extension to the navigator interface with an `install` method. This method receives:
 * `manifest_id`: declares the specific application to be installed. This is the unique id of the application that will be installed. This value must match the id specified in the manifest file. 
-* `install_url`: a url meant for installing an app. This url can be any url in scope of the manifest file that links to it. An `install_url` must not redirect nor contain extra content that is not relevant for installation purposes. In the absence of an `install_url`, the value defaults to that of the `manifest_id`.
+* `install_url`: a url meant for installing an app. This url can be any url in scope of the manifest file that links to it. An `install_url` must not redirect nor contain extra content that is not relevant for installation purposes. In the absence of an `install_url`, the value defaults to that of the manifest's `start_url`.
 * optional [parameters](#parameters).
 
 If the `manifest_id` is the *what* to install, the `install_url` is the *where* to find it.
@@ -89,9 +89,7 @@ Unless the UA decides to [gate this functionality behind installation](#gating-c
 
 1. `navigator.install(<manifest_id>, <install_url> [, <params>])`: This signature of the method requires the id of the application to be installed (`manifest_id`), and the installation location for the app (`install_url`). This is the most common API use case the API for cross-origin scenarios.
 
-2. `navigator.install(<manifest_id> [, <params>])`: The method receives a parameter which is a [manifest id](https://w3c.github.io/manifest/#id-member) to a web app to install. There is no explicit `install_url`, which means it is the same value as the `manifest_id`. This is a shorthand to calling `navigator.install(<manifest_id>, <manifest_id>)`.
-
-In both cases, this will prompt for installation of the app if the requesting origin has installation permissions (see [security section](#integration-with-the-permissions-api)) and the target application has specified this domain in its `install_sources` manifest field.
+This will prompt for installation of the app if the requesting origin has installation permissions (see [security section](#integration-with-the-permissions-api)) and the target application has specified this domain in its `install_sources` manifest field.
 
 #### **Parameters**
 

--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -98,7 +98,7 @@ The same-origin part of the  Web Install API consists of the extension to the na
 
 1. `navigator.install([<params>])`: The method receives no parameters and tries to install the current origin as an app. Note that `manifest_id` *is required* for the installation and if the method is called without one it will use the *default* manifest id of the web content which resolves to the document url.
 
-2. `navigator.install(manifest_id, [<params>])`: The method takes a manifest id and tries to install the current origin as an app. If the content being installed has a manifest file, this must match the value in the manifest file. If there is no manifest file present, it must match the document url. The call can also receive an object with parameters that it can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
+2. `navigator.install(manifest_id[[, install_url], <params>])`: The method takes a manifest id and optional install url and tries to install the current origin as an app. If the content being installed has a manifest file, this must match the value in the manifest file. If there is no manifest file present, it must match the document url. The call can also receive an object with parameters that it can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
 
 #### **Parameters**
 


### PR DESCRIPTION
* sets falback value for `install_url` ro `start_url`.

* removes the second signature for the cross-origin method since it based based on an error that the default for `install_url` was `manifest_id`.

fixes #747 