### PR TITLE
Update upstream OTs for 26 Feb 2024

### DIFF
--- a/origin-trials/upstream-trials.json
+++ b/origin-trials/upstream-trials.json
@@ -106,7 +106,7 @@
       "label": "RTCEncodedFrameSetMetadata",
       "expiration": "2024-09-03",
       "repo": "w3c/webrtc-nv-use-cases",
-      "explainer": "about:invalid#zClosurez"
+      "explainer": " https://github.com/palak8669/webrtc-encoded-transform/blob/create-encoded-explainer/create-encoded-explainer.md"
     },
     {
       "label": "RTCPeerConnection callback-based getStats() API",


### PR DESCRIPTION
No real changes from last week, but an [update](https://microsoft.visualstudio.com/DefaultCollection/Edge/_git/edge.cs.origin-trials/pullrequest/10345916) to the OT scraper script fixes a broken explainer link.