### PR TITLE
Remove PointerEvent.deviceId OT

### DIFF
--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -8,13 +8,6 @@
             "issue": "Acquisition Info",
             "flag": "msAcquisitionInfo"
         },{
-            "label": "PointerEvent.deviceId",
-            "expiration": "2024-07-01",
-            "repo": "MicrosoftEdge/MSEdgeExplainers",
-            "issue": "PointerEventDeviceId",
-            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PointerEventDeviceId/explainer.md",
-            "flag": "PointerEventDeviceId"
-        },{
           "label": "HTML+IDL `handwriting` attribute",
           "expiration": "2024-11-14",
           "repo": "MicrosoftEdge/MSEdgeExplainers",


### PR DESCRIPTION
Remove the PointerEvent.deviceId Origin Trial because the shape of this API is changing. See https://chromium-review.googlesource.com/c/chromium/src/+/5388651 and https://github.com/w3c/pointerevents/pull/495.