### PR TITLE
Remove expired Acquisition Info API trial

### DIFF
--- a/origin-trials/downstream-trials.json
+++ b/origin-trials/downstream-trials.json
@@ -1,14 +1,6 @@
 {
     "active": [
         {
-            "label": "Acquisition Info API",
-            "expiration": "2024-05-21",
-            "repo": "MicrosoftEdge/MSEdgeExplainers",
-            "explainer": "https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/AcquisitionInfo/explainer.md",
-            "issue": "Acquisition Info",
-            "flag": "msAcquisitionInfo"
-        },
-        {
             "label": "HTML+IDL `handwriting` attribute",
             "expiration": "2024-11-14",
             "repo": "MicrosoftEdge/MSEdgeExplainers",


### PR DESCRIPTION
This trial has expired. Remove it.