### PR TITLE
Require id in manifest and support 0 param installation

### DIFF
--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -94,8 +94,8 @@ const installApp = async () => {
 #### **Signatures of the `install` method (same-origin)**
 The same-origin part of the  Web Install API consists of the extension to the navigator interface with the install method. The install method can be used in several different ways. There is no difference in behaviour when this is called from a standalone window or a tab.
 
-1. `navigator.install(<params>)`: The method takes no parameters and tries to install the current document. If the content to be installed does not link to a manifest with an explicitly defined `id` value, then installation will fail.
-2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. If the content to be installed does not link to a manifest OR if the manifest does not include a valid id OR if the id parameter does not match either the declared or resolved manifest id, then installation will fail.
+1. `navigator.install(<params>)`: The method takes no parameters and tries to install the current document. Installation will proceed as long as the current document links to a manifest that includes a declared id.
+2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. Installation will proceed as long as the target web app has a declared id in its manifest and the `id` parameter either matches the declared or resolved manifest id.
 
 Both calls can also receive an object with parameters that they can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
 

--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -95,7 +95,10 @@ const installApp = async () => {
 The same-origin part of the  Web Install API consists of the extension to the navigator interface with the install method. The install method can be used in several different ways. There is no difference in behaviour when this is called from a standalone window or a tab.
 
 1. `navigator.install(<params>)`: The method takes no parameters and tries to install the current document. Installation will proceed as long as the current document links to a manifest that includes a declared id.
-2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. Installation will proceed as long as the target web app has a declared id in its manifest and the `id` parameter either matches the declared or resolved manifest id.
+2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. Installation will proceed if the following are true:
+   a. The target web app links to a manifest.
+   b. The target web app's manifest includes either an `id` or `start_url`.
+   c. The `id` parameter matches the declared or resolved id of the target web app.
 
 Both calls can also receive an object with parameters that they can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
 

--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -42,11 +42,11 @@ The current way of supporting installation is vai the `onbeforeinstallprompt` ev
 The `navigator.install` method allows a imperative way to install web content, and works for UAs that prompt and don't prompt:
 
 ```javascript
-/* tries to install the current domain */
+/* tries to install the current document */
 const installApp = async () => {
     if (!navigator.install) return; // api not supported
     try {
-        await navigator.install('content_id_123');
+        await navigator.install();
     } catch(err) {
         switch(err.name){
             case 'AbortError':
@@ -61,7 +61,7 @@ const installApp = async () => {
 
 The **`navigator.install` method can overlap with some functionality of `beforeinstallprompt` for same-origin installation**. When the method is called it will trigger the UA to prompt for the installation of an application. This is analogous to when the end user clicks on an affordance that the UA might have to inform the user of installing. On Edge, Chrome (desktop) and Samsung Internet (mobile), this would be when the user clicks on the 'app available' banner or related UX that appears on the omnibox of the browser. For browsers that do not implement prompting, the expected behaviour is analogous to their installation paradigm. For example, in Safari (desktop) the behaviour might be that it shows a dialog to add the content to the dock as an app.
 
-On UAs that support prompting, the threshold for `navigator.install` to resolve on same-origin installations uses the same checks that `onbeforeinstallprompt` currently has for prompting (if required by the UA). The promise doesn't resolve unless the *installability criteria* is met. *Note that the criteria defined by UAs varies and can be that there is NO criteria*.
+On UAs that support prompting, the threshold for `navigator.install` to resolve on same-origin installations uses the same checks that `onbeforeinstallprompt` currently has for prompting (if required by the UA). The promise doesn't resolve unless the *installability criteria* is met. *Note that the criteria defined by UAs varies and can be that there is NO criteria aside from requiring an id in the site's manifest*.
 
 When called on the same domain, the **`install` method will trigger/open the prompt for installation the same way that using `onbeforeinstallprompt` does right now for browser that prompts.** If there is an error with the installation, then the promise returns a `DOMException` of type 'AbortError'. 
 
@@ -72,7 +72,7 @@ When called on the same domain, the **`install` method will trigger/open the pro
 
 ### The `navigator.install` method
 
-To install a web site/app, the site/app would use the promise-based method`navigator.install(<id>[[, install_url], <params>])`. This method will:
+To install a web site/app, the site/app would use the promise-based method `navigator.install(id, install_url, [<params>])`. This method will:
 
 * Resolve when an installation was completed.
     * The success value will be an object that contains:
@@ -85,7 +85,7 @@ To install a web site/app, the site/app would use the promise-based method`navig
 
 const installApp = async () => {
     try{
-        const value = await navigator.install('content_id_123');
+        const value = await navigator.install();
     }
     catch(err){console.error(err.message)}
 };
@@ -96,8 +96,10 @@ const installApp = async () => {
 #### **Signatures of the `install` method (same-origin)**
 The same-origin part of the  Web Install API consists of the extension to the navigator interface with the install method. The install method can be used in several different ways. There is no difference in behaviour when this is called from a standalone window or a tab.
 
-1. `navigator.install(id[[, install_url], <params>])`: The method takes an id (and optional install url) and tries to install the current origin. If the content being installed has a manifest file, this `id` must match the value in the manifest file. If there is no manifest file present, this `id` will act as the app id for the installed content. This is relevant since if the installed content were to be given a manifest file and made into an application, there is a way to automatically update the app going forward. 
-The call can also receive an object with parameters that it can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
+1. `navigator.install()`: The method takes no parameters and tries to install the current document. If the content to be installed does not link to a manifest with a valid id, then installation will fail.
+2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. If the content to be installed does not have a linked manifest that specifies an id, and the provided `id` parameter does not match the computed id, then installation will fail.
+
+Both calls can also receive an object with parameters that they can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
 
 #### **Parameters**
 

--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -37,7 +37,7 @@ Modern browsers have UX that enable users to *install* web content on their devi
 ### **Installing a web app from the current origin**
 The site can trigger its own installation. 
 
-The current way of supporting installation is vai the `onbeforeinstallprompt` event, which only works in browsers that have a prompting UI affordace. 
+The current way of supporting installation is via the `onbeforeinstallprompt` event, which only works in browsers that have a prompting UI affordance. 
 
 The `navigator.install` method allows a imperative way to install web content, and works for UAs that prompt and don't prompt:
 
@@ -64,8 +64,6 @@ The **`navigator.install` method can overlap with some functionality of `beforei
 On UAs that support prompting, the threshold for `navigator.install` to resolve on same-origin installations uses the same checks that `onbeforeinstallprompt` currently has for prompting (if required by the UA). The promise doesn't resolve unless the *installability criteria* is met. *Note that the criteria defined by UAs varies and can be that there is NO criteria aside from requiring an id in the site's manifest*.
 
 When called on the same domain, the **`install` method will trigger/open the prompt for installation the same way that using `onbeforeinstallprompt` does right now for browser that prompts.** If there is an error with the installation, then the promise returns a `DOMException` of type 'AbortError'. 
-
-*Any same-origin content can be installed even if it is **NOT** an application.*
 
 
 ## Proposed Solution
@@ -97,7 +95,7 @@ const installApp = async () => {
 The same-origin part of the  Web Install API consists of the extension to the navigator interface with the install method. The install method can be used in several different ways. There is no difference in behaviour when this is called from a standalone window or a tab.
 
 1. `navigator.install()`: The method takes no parameters and tries to install the current document. If the content to be installed does not link to a manifest with a valid id, then installation will fail.
-2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. If the content to be installed does not have a linked manifest that specifies an id, and the provided `id` parameter does not match the computed id, then installation will fail.
+2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. If the content to be installed does not link to a manifest OR if the manifest does not include a valid id OR if the id parameter does not match either the declared or resolved manifest id, then installation will fail.
 
 Both calls can also receive an object with parameters that they can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.
 
@@ -117,7 +115,7 @@ To install a same domain web site/app, the process is as follows:
    
 ## Relation with other web APIs 
 
-* **`navigator.install` and manifest file's `prefer_related_applications`:** When the `related_applications` and `prefer_related_applications` key/values are present in the manifest, the UA should try to handoff the install to the prefered catalog. If this is not possible then it fallback to a default UA install.
+* **`navigator.install` and manifest file's `prefer_related_applications`:** When the `related_applications` and `prefer_related_applications` key/values are present in the manifest, the UA should try to handoff the install to the preferred catalog. If this is not possible then it fallback to a default UA install.
 
 * **`navigator.install` and getInstalledRelatedApps():** If a web app tries to install itself (same domain install) it can first use the `getInstalledRelatedApps()` to check if it is already installed and hide the installation UI.
 
@@ -160,8 +158,10 @@ A user agent might decide to have only the requirement of HTTPS to allow install
 * Should we allow an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to enable cancelling the installation if the process takes too long?
 
 ## Glossary
-* **installation origin**: the origin that initiates the call to the `install` method.
-* **installed origin**: the origin that is installed with the `install` method.
+* **Installation origin**: The origin that initiates the call to the `install` method.
+* **Installed origin**: The origin that is installed with the `install` method.
+* **Declared manifest id**: The id as it is declared in the manifest. See [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Manifest/id) for more info.
+* **Resolved manifest id**: The processed id after it is resolved against the `start_url`'s origin. Since the declared id is resolved against an origin, this will take the form of a url (e.g. "https://example.com/my_app"), although it may not point to a valid resource. See [W3 manifest spec](https://www.w3.org/TR/appmanifest/#id-member) for detailed parsing info.
 
 ## Acknowledgements
 

--- a/WebInstall/explainer_same_domain.md
+++ b/WebInstall/explainer_same_domain.md
@@ -94,7 +94,7 @@ const installApp = async () => {
 #### **Signatures of the `install` method (same-origin)**
 The same-origin part of the  Web Install API consists of the extension to the navigator interface with the install method. The install method can be used in several different ways. There is no difference in behaviour when this is called from a standalone window or a tab.
 
-1. `navigator.install()`: The method takes no parameters and tries to install the current document. If the content to be installed does not link to a manifest with a valid id, then installation will fail.
+1. `navigator.install(<params>)`: The method takes no parameters and tries to install the current document. If the content to be installed does not link to a manifest with an explicitly defined `id` value, then installation will fail.
 2. `navigator.install(id, install_url, [<params>])`: The method takes an id and install url and tries to install the web content at `install_url`. If the content to be installed does not link to a manifest OR if the manifest does not include a valid id OR if the id parameter does not match either the declared or resolved manifest id, then installation will fail.
 
 Both calls can also receive an object with parameters that they can use to customize a same domain installation. These parameters alter how the app is installed and are defined in an object. More information about the parameters is found in the [Parameters](#parameters) subsection of this specification.


### PR DESCRIPTION
Updates the same-origin Web Install explainer to support a 0-param installation (instead of requiring a single `id` param) and adds the requirement that the app to-be-installed must have a manifest with an `id` field.  