### PR TITLE
Update Handwriting explainer

### DIFF
--- a/Handwriting/HandwritingIntentCSSValue.md
+++ b/Handwriting/HandwritingIntentCSSValue.md
@@ -97,12 +97,12 @@ All CSS properties have computed values for all elements. The enablement of hand
 1. If the computed value for `touch-action` on `element` and all of its ancestors include either keyword `auto`, `handwriting`, or `manipulation`, **enable handwriting**.
 2. If the computed value for `touch-action` on `element` or any of its ancestors does not include either keyword `auto`, `handwriting`, or `manipulation`, **disable handwriting**.
 
-### Caveats
+### Caveats / Cons
 
 A few pain points have been brought up that are worth discussion:
 * Web pages that currently have the `touch-action` property set for different elements will lose the handwriting capabilities on this element even if they don't want to disable it. When the new keyword ships, the absence of the value will be interpreted as the author of the webpage intentionally disabling handwriting.
 * Authors that specify `touch-action: manipulation` will be enabling `handwriting`, even when they might not want the behavior enabled in their webpage. These authors would then need to update their webpages to explicitly mention which behaviors they want, i.e. : `touch-action: pan-x pan-y pinch-zoom`.
-
+*   Using `touch-action` restricts handwriting implementations to touch controls (such as stylus and touch), even though a platform could support handwriting capabilities for other controls, like mouse pointer events.
 ## Privacy and Security Considerations
 
 ### Privacy
@@ -113,12 +113,13 @@ Since the proposed property should not interact with other HTML or IDL attribute
 
 There are no known security impacts of the features in this specification.
 
-## Alternative Solutions
+# Alternative Solutions
 
-The proposal is for this to be an CSS property.
 ## Why not an HTML+IDL attribute?
 
-The [first proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Handwriting/explainer.md) was to add the handwriting functionality as an HTML+IDL attribute, but after some discussion it was decided that the better option was to implement the functionality in the `touch-action` CSS attribute. [ [1](https://groups.google.com/a/chromium.org/g/blink-dev/c/0r_tV6k0NyA?pli=1)]] [[2](https://github.com/w3c/pointerevents/issues/516)]
+The [first proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Handwriting/explainer.md) was to add the handwriting functionality as an HTML+IDL attribute which would allow authors to specify whether an element should permit handwriting by adding a new `handwriting(= true|= false|<blank>)` (`<blank>` implying `= true`) attribute to HTML elements.
+
+After some discussion [[1](https://groups.google.com/a/chromium.org/g/blink-dev/c/0r_tV6k0NyA?pli=1)]] [[2](https://github.com/w3c/pointerevents/issues/516)], it became apparent that implementing the functionality in the `touch-action` CSS attribute was the better alternative. The discussion is still ongoing, and we are open to considering different alternatives.
 
 * [Pro] If users or organizations disable CSS for their browsers there would need to be another mechanism to disable handwriting input.
 * [Pro] All websites that currently use `touch-action` won't have to update their rules if they want handwriting to be enabled.
@@ -126,8 +127,7 @@ The [first proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main
 * [Con] Developers would have to keep track of both the `touch-action` CSS property and new HTML attribute in order to completely declare the desired behavior of their webpages.
  * [Con] CSS pattern matching is a powerful tool and may be more ergonomic for some use cases.
 
-
-#### Why not an HTML+IDL attribute that interacts with `touch-action`?
+### Why not an HTML+IDL attribute that interacts with `touch-action`?
 
 `touch-action:none;` is the accepted and recommended way of disabling all types of touch interaction with the elements. The HTML attribute would not be able to override the `touch-action` property in these scenarios. By accepting touch-action as a filter, developers would lose the flexibility of disabling scrolling while enabling handwriting. Consider the following scenarios:
 

--- a/Handwriting/HandwritingIntentCSSValue.md
+++ b/Handwriting/HandwritingIntentCSSValue.md
@@ -88,8 +88,8 @@ Authors are used to the [recommended practice of adding touch-action: none](http
 
 ### Keywords and States
 
- The `touch-action` attribute accepts the following keywords:
-> Value: `auto` | `none` | [ [ `pan-x` | `pan-left` | `pan-right` ] | [ `pan-y` | `pan-up` | `pan-down` ] ] | `manipulation`
+ The `touch-action` attribute currently accepts the following keywords:
+> Value: `auto` | `none` | [ [ `pan-x` | `pan-left` | `pan-right` ] | [ `pan-y` | `pan-up` | `pan-down` ] ] | `pinch-zoom` | `manipulation`
 
 The `handwriting` keyword indicates whether an element and the element's descendants will allow handwriting input when supported by the user agent. Handwriting will only be allowed for an element when its computed `touch-action` includes the `handwriting` keyword. By default, `auto` and `manipulation` will include the `handwriting` keyword.
 
@@ -108,7 +108,7 @@ A few pain points have been brought up that are worth discussion:
 * Web pages that currently have the `touch-action` property set for different elements will lose the handwriting capabilities on this element even if they don't want to disable it. When the new keyword ships, the absence of the value will be interpreted as the author of the webpage intentionally disabling handwriting.
 * Authors that specify `touch-action: manipulation` will be enabling `handwriting`, even when they might not want the behavior enabled in their webpage. These authors would then need to update their webpages to explicitly mention which behaviors they want, i.e. : `touch-action: pan-x pan-y pinch-zoom`.
 *   Using `touch-action` restricts handwriting implementations to touch input devices (such as stylus and touch), even though a platform could support handwriting capabilities for other controls, like mouse pointer events.
-	* `touch-action` determines the behavior of touch input devices indistinctly of which device is being used, either touch or stylus. In the future, these input devices might be separated into two different CSS attributes to allow things like, say, enable panning with finger touch events and only enable handwriting with a stylus.  
+	* `touch-action` determines which behaviors are allowed for touch input devices regardless of which device is being used, either touch or stylus. In the future, these input devices might be separated into two different CSS attributes to allow things like, say, enable panning with finger touch events and only enable handwriting with a stylus.  
 ## Privacy and Security Considerations
 
 ### Privacy
@@ -167,7 +167,7 @@ The last entry that fails is equivalent of `touch-action: handwriting`. In order
 ## References and acknowledgements
 
 * @**[flackr](https://github.com/flackr)**, @**[mustaqahmed](https://github.com/mustaqahmed)**, @**[adettenb](https://github.com/adettenb)**, @**[patrickhlauke](https://github.com/patrickhlauke)**, @**[ogerchikov](https://github.com/ogerchikov)** for helping build this proposal and providing feedback.
-* **Claire Chambers**, @**[dandclark](https://github.com/dandclark)**, @**[kbabbitt](https://github.com/kbabbitt)**, @**[sanketj](https://github.com/sanketj)** and  **@[sfortiner](https://github.com/sfortiner)** , for helping with the [HTML+IDL explainer](Handwriting/explainer.md). Their feedback has been invaluable for completing these documents, and much of it carried over into this document.
+* **Claire Chambers**, @**[dandclark](https://github.com/dandclark)**, @**[kbabbitt](https://github.com/kbabbitt)**, @**[sanketj](https://github.com/sanketj)** and  **@[sfortiner](https://github.com/sfortiner)** , for helping with the [HTML+IDL explainer](explainer.md). Their feedback has been invaluable for completing these documents, and much of it carried over into this document.
 
 ## Stakeholder Feedback / Opposition
 

--- a/Handwriting/HandwritingIntentCSSValue.md
+++ b/Handwriting/HandwritingIntentCSSValue.md
@@ -102,7 +102,8 @@ All CSS properties have computed values for all elements. The enablement of hand
 A few pain points have been brought up that are worth discussion:
 * Web pages that currently have the `touch-action` property set for different elements will lose the handwriting capabilities on this element even if they don't want to disable it. When the new keyword ships, the absence of the value will be interpreted as the author of the webpage intentionally disabling handwriting.
 * Authors that specify `touch-action: manipulation` will be enabling `handwriting`, even when they might not want the behavior enabled in their webpage. These authors would then need to update their webpages to explicitly mention which behaviors they want, i.e. : `touch-action: pan-x pan-y pinch-zoom`.
-*   Using `touch-action` restricts handwriting implementations to touch controls (such as stylus and touch), even though a platform could support handwriting capabilities for other controls, like mouse pointer events.
+* Using `touch-action` restricts handwriting implementations to touch input devices (such as stylus and touch), even though a platform could support handwriting capabilities for other controls, like mouse pointer events.
+
 ## Privacy and Security Considerations
 
 ### Privacy
@@ -115,17 +116,18 @@ There are no known security impacts of the features in this specification.
 
 # Alternative Solutions
 
+The proposal is for this to be an CSS property.
 ## Why not an HTML+IDL attribute?
 
-The [first proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Handwriting/explainer.md) was to add the handwriting functionality as an HTML+IDL attribute which would allow authors to specify whether an element should permit handwriting by adding a new `handwriting(= true|= false|<blank>)` (`<blank>` implying `= true`) attribute to HTML elements.
-
-After some discussion [[1](https://groups.google.com/a/chromium.org/g/blink-dev/c/0r_tV6k0NyA?pli=1)]] [[2](https://github.com/w3c/pointerevents/issues/516)], it became apparent that implementing the functionality in the `touch-action` CSS attribute was the better alternative. The discussion is still ongoing, and we are open to considering different alternatives.
-
+The [first proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Handwriting/explainer.md) was to add the handwriting functionality as an HTML+IDL attribute which would allow authors to specify whether an element should permit handwriting by adding a new `handwriting(= true|= false|<blank>)` (`<blank>` implying `= true`) attribute to HTML elements. The main arguments to implement the handwriting HTML attribute **over** a css property are: 
 * [Pro] If users or organizations disable CSS for their browsers there would need to be another mechanism to disable handwriting input.
-* [Pro] All websites that currently use `touch-action` won't have to update their rules if they want handwriting to be enabled.
-* [Pro] An HTML attribute can be exposed to JavaScript as a IDL attribute which may be more ergonomic.
-* [Con] Developers would have to keep track of both the `touch-action` CSS property and new HTML attribute in order to completely declare the desired behavior of their webpages.
- * [Con] CSS pattern matching is a powerful tool and may be more ergonomic for some use cases.
+* [Pro] All websites that currently use `touch-action` won't have to update their rules if they want handwriting to be enabled (see **# Caveats / Cons**).
+
+After some discussion [[1](https://groups.google.com/a/chromium.org/g/blink-dev/c/0r_tV6k0NyA?pli=1)] [[2](https://github.com/w3c/pointerevents/issues/516)], it became apparent that implementing the functionality in the `touch-action` CSS attribute was the better alternative. The main arguments in favor of `touch-action` were:
+
+* Authors are used to the [recommended practice of adding touch-action: none](https://w3c.github.io/pointerevents/#example_10) to elements over which they wish to handle all events themselves. In order to allow sites for which authors following this recommended practice to continue working, we should treat stylus handwriting as a "direct manipulation" action, which is similarly prevented by touch-action.
+* If implemented as an HTML attribute, `touch-action`'s interaction with the attribute would have to be clearly defined and possibly clash with authors' expectations (see following section). 
+
 
 ### Why not an HTML+IDL attribute that interacts with `touch-action`?
 

--- a/Handwriting/HandwritingIntentCSSValue.md
+++ b/Handwriting/HandwritingIntentCSSValue.md
@@ -88,9 +88,14 @@ Authors are used to the [recommended practice of adding touch-action: none](http
 
 ### Keywords and States
 
+ The `touch-action` attribute accepts the following keywords:
+> Value: `auto` | `none` | [ [ `pan-x` | `pan-left` | `pan-right` ] | [ `pan-y` | `pan-up` | `pan-down` ] ] | `manipulation`
+
 The `handwriting` keyword indicates whether an element and the element's descendants will allow handwriting input when supported by the user agent. Handwriting will only be allowed for an element when its computed `touch-action` includes the `handwriting` keyword. By default, `auto` and `manipulation` will include the `handwriting` keyword.
 
-#### Determining enablement
+Note that `touch-action` does not indicate that some actions should take precedence over others, so discerning which interaction the pointer events should trigger will be the responsibility of the User Agent. For example, differentiating between a _pan-*_ gesture and a _handwriting_ gesture if both are avaialable. 
+
+### Determining enablement
 
 All CSS properties have computed values for all elements. The enablement of handwriting in a given `element` can be determined by running the following steps:
 
@@ -102,8 +107,8 @@ All CSS properties have computed values for all elements. The enablement of hand
 A few pain points have been brought up that are worth discussion:
 * Web pages that currently have the `touch-action` property set for different elements will lose the handwriting capabilities on this element even if they don't want to disable it. When the new keyword ships, the absence of the value will be interpreted as the author of the webpage intentionally disabling handwriting.
 * Authors that specify `touch-action: manipulation` will be enabling `handwriting`, even when they might not want the behavior enabled in their webpage. These authors would then need to update their webpages to explicitly mention which behaviors they want, i.e. : `touch-action: pan-x pan-y pinch-zoom`.
-* Using `touch-action` restricts handwriting implementations to touch input devices (such as stylus and touch), even though a platform could support handwriting capabilities for other controls, like mouse pointer events.
-
+*   Using `touch-action` restricts handwriting implementations to touch input devices (such as stylus and touch), even though a platform could support handwriting capabilities for other controls, like mouse pointer events.
+	* `touch-action` determines the behavior of touch input devices indistinctly of which device is being used, either touch or stylus. In the future, these input devices might be separated into two different CSS attributes to allow things like, say, enable panning with finger touch events and only enable handwriting with a stylus.  
 ## Privacy and Security Considerations
 
 ### Privacy


### PR DESCRIPTION
Adding a new Con emphasizing that using `touch-action` would cause us to limit handwriting enablement to touch controls and a little bit more context on the HTML proposal.