### PR TITLE
Aria notify updates

### DIFF
--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -162,7 +162,7 @@ as the concept of [earcons](https://en.wikipedia.org/wiki/Earcon)). Without addi
 options can be offered: options that apply to all `ariaNotify` notifications universally or customization on a
 per-notification-string basis. 
 
-To aid in customization, `ariaNotify` provides a method to give context of the notification (`notificationId`). This
+To aid in customization, `ariaNotify` provides a method to give context of the notification (`type`). This
 explainer provides a set of potential suggestions but allows for arbitrary non-localized strings to be used by the
 content author. All strings will be processed by the user agent according to a fixed algorithm ([ASCII
 encode](https://infra.spec.whatwg.org/#ascii-encode), then [ASCII
@@ -170,11 +170,11 @@ lowercase](https://infra.spec.whatwg.org/#ascii-lowercase), and finally, [strip 
 whitespace](https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace)) before the notification is sent
 to the platform API (invalid strings will throw an exception). 
 
-When no `notificationId` is explicitly provided by the content author, the `notificationId` is set to `notify` by
+When no `type` is explicitly provided by the content author, the `type` is set to `notify` by
 default.
 
-To specify a `notificationId`, pass the string as the second parameter.  Alternatively, the `notificationId` may be
-expressed in an object form with property `notificationId`. For example: 
+To specify a `type`, pass the string as the second parameter.  Alternatively, the `type` may be
+expressed in an object form with property `type`. For example: 
 
 #### Example 2
 ```
@@ -185,11 +185,11 @@ document.ariaNotify(
 // ... 
 myfile.asyncFileUpload().then( () => { 
     document.ariaNotify( "File untitled-1 uploaded.", { 
-         notificationId: "task-progress-finished" } ); 
+         type: "task-progress-finished" } ); 
 }); 
 ```
 
-Screen readers may allow their users to filter out these task-progress `notificationId`, may make these notifications
+Screen readers may allow their users to filter out these task-progress `type`, may make these notifications
 only available at particular verbosity levels, or may replace the output strings with audio cues. 
 
 ### Managing pending notifications 
@@ -219,12 +219,12 @@ notifications:
 // Dispatch a notification updating background task status -- normal/low priority
 document.ariaNotify( "Background task completed",
     { "priority":"normal",
-      "notificationId":"StatusUpdate" }); 
+      "type":"StatusUpdate" }); 
 
 // Dispatch a high priority notification that data may be lost
 document.ariaNotify("Unable to save changes, lost connection to server",
     { "priority":"high",
-      "notificationId":"ServerError" }); 
+      "type":"ServerError" }); 
 ```
 
 Assuming the initial normal priority string hasn't already started to be acted upon (spoken/brailled), the high priority
@@ -239,19 +239,19 @@ the user first.
 // sent to the user 
 document.querySelector("#dataStatus")
         .ariaNotify( "generating content",
-            { "notificationId":"statusUpdate" }); 
+            { "type":"statusUpdate" }); 
 
 document.querySelector("#dataStatus")
         .ariaNotify( "processing data ", 
-            { "notificationId":"statusUpdate" }); 
+            { "type":"statusUpdate" }); 
 
 document.querySelector("#dataStatus")
         .ariaNotify( "counting items ",
-            { "notificationId":"statusUpdate" } ); 
+            { "type":"statusUpdate" } ); 
 
 document.ariaNotify( " server connection lost ",
             { "priority":"high",  
-              "notificationId":"serverStatus" } ); 
+              "type":"serverStatus" } ); 
 ```
 
 As content is being generated, the user is informed of that status. When something more serious occurs, such as losing
@@ -295,7 +295,7 @@ function simulateProgress() {
   // update to be fully spoken 
   document.querySelector("#progressBar")
           .ariaNotify( "Progress is ${currentValue}", 
-            { "notificationId": "progressBar", 
+            { "type": "progressBar", 
               "priority":"normal",
               "interrupt":"none" });
 }
@@ -323,7 +323,7 @@ function simulateProgress() {
   // pending percentages, and add the latest 
   document.querySelector("#progressBar")
           .ariaNotify( "Progress is ${currentValue}",
-            { "notificationId":"progressBar",
+            { "type":"progressBar",
               "priority":"normal",
               "interrupt":"all" });
  }
@@ -354,7 +354,7 @@ function simulateProgress() {
   // latest 
   document.querySelector("#progressBar")
           .ariaNotify( "Progress is ${currentValue}",
-              { "notificationId":"progressBar", 
+              { "type":"progressBar", 
                 "priority":"normal",
                 "interrupt":"pending" }); 
 }
@@ -387,7 +387,7 @@ directly to ARIA live regions.
 In the case of browsers that do not yet support `ariaNotify`, we propose the following fallback mechanism using the same
 backend as the existing ARIA live regions: 
  - The message payload for `ariaNotify` is equivalent to the contents of an ARIA live region. 
- - The `notificationId` is dropped entirely. 
+ - The `type` is dropped entirely. 
  - `"priority: high"` and `"priority: normal"` correspond to `aria-live="assertive"` and `aria-live="polite"` ARIA
  live attributes, respectively. 
  - ARIA live regions do not support interruptibility, so all behavior of `interrupt` defaults to `none`.  
@@ -420,13 +420,13 @@ if ("ariaNotify" in element) {
 ```
 
 ## Open Issues 
-### Predefined notificationIds 
-The use of `notificationId` give the screen reader contextual information regarding the notification which allows for
+### Predefined types 
+The use of `type` give the screen reader contextual information regarding the notification which allows for
 creative approaches to dispatching the information to their users. The question then arises of whether the API should
-create a predetermined set of `notificationId` names for common/expected scenarios or whether having predefined names is
+create a predetermined set of `type` names for common/expected scenarios or whether having predefined names is
 pointless given no matter the list, it will always fall short. 
 
-Possible examples of predefined `notificationId` could be something like: 
+Possible examples of predefined `type` could be something like: 
  - Recent action completion status: `action-completion-success`, `action-completion-warning`,
  `action-completion-failure` 
  - Async/indeterminate task progress: `task-progress-started`, `task-progress-ongoing`, `task-progress-blocked`,
@@ -504,8 +504,8 @@ Adding `ariaNotify` to Elements was driven by several goals:
 
 Screen reader users can customize the verbosity of the information (and context) that is read to them via settings.
 Screen reader vendors can also adapt the screen reader on a per site or per app basis for the best experience of their
-users. `ariaNotify` offers `notificationId` as a mechanism to allow screen reader vendors or users to customize not only the
-general use of `ariaNotify` on websites, but also individual notifications by `notificationId` (or specific notification
+users. `ariaNotify` offers `type` as a mechanism to allow screen reader vendors or users to customize not only the
+general use of `ariaNotify` on websites, but also individual notifications by `type` (or specific notification
 string instances in the limit). 
 
 **Tooling help**

--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -1,6 +1,6 @@
 # ARIA Notify
 
-Authors: [Doug Geoffray](), [Alison Maher](), [Sara Tang](https://github.com/sartang), [Travis Leithead](https://github.com/travisleithead), [Daniel Libby](https://github.com/dlibby-)
+Authors: [Doug Geoffray](), [Alison Maher](), [Sara Tang](https://github.com/sartang), [Travis Leithead](https://github.com/travisleithead), [Daniel Libby](https://github.com/dlibby-), [Andy Luhrs](https://github.com/aluhrs13)
 
 ## Introduction
 
@@ -215,7 +215,7 @@ A previous version of this explainer included an `interrupt` property (now descr
 ## Future considerations 
 `ariaNotify` can be extended in the future to handle more functionality as needs arise. We've discussed a few of these in-depth and have included them below.
 
-### Braille and pronunciations
+### Braille and speech markup
 There may be a need for a web author to supply a Braille specific string separate from the speech string. For example, an author could supply "3 stars" as the speech string to indicate a retail item's rating. However, to better map within a Braille display, the author could supply `***` as a Braille alternative string. The API could easily be extended by adding another optional property for Braille strings. For example: 
 
 ```js
@@ -232,6 +232,10 @@ For example, maybe you would like "911" pronounce as "9 1 1" in some cases. Or i
 document.ariaNotify( "911", {"SSML":"<say-as
 interpret-as=\x22\"""digits\x22""">911" });
 ``` 
+
+Related issues:
+- [w3c/aria #2334](https://github.com/w3c/aria/issues/2334)
+- [w3c/aria #2335](https://github.com/w3c/aria/issues/2335)
 
 ### Interruption
 #### Use Case
@@ -264,10 +268,10 @@ on the source, priority, and interrupt settings of the current and pending notif
    remove/flush all of them. 
    - Step 3: Add the notification to pending notifications as per its priority. 
 
-#### Example 3 - `interrupt`
+Related issue - [w3c/aria #2331](https://github.com/w3c/aria/issues/2331)
 
-`ariaNotify` can allow more scenarios than Live Regions. Here is a simple example showing three outcomes for the same
-scenario (a progress bar which reports its status at every percent increment): 
+#### Example 3 - `interrupt`
+Here is a simple example showing three outcomes for the same scenario (a progress bar which reports its status at every percent increment): 
 
 ##### Example 3.1
 `interrupt:none` - Every progress bar percentage from 1% to 100% will be spoken. 
@@ -472,6 +476,8 @@ Possible examples of predefined `type` could be something like:
   - `ui-enabled / ui-disabled`
   - `ui-editable / ui-readonly`
   - `ui-selected / ui-unselected`
+
+  Related issue - [w3c/aria #2330](https://github.com/w3c/aria/issues/2330)
 
 ## FAQ 
 **Is this API going to lead to privacy concerns for AT users?**

--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -208,26 +208,26 @@ notifications.
 
 `priority` indicates where the screen reader should add the notification in relationship to any existing pending
 notifications: 
- - `important` 
-   - Screen reader should add this string to the end of any other pending important notifications but before all
-   non-important pending notifications  
- - `none` - (default) 
+ - `high` 
+   - Screen reader should add this string to the end of any other pending high priority notifications but before all
+   normal priority pending notifications  
+ - `normal` - (default) 
    - Screen reader should add this string to the end of all pending notifications. 
 
 #### Example 3
 ```
-// Dispatch a notification updating background task status -- low priority
+// Dispatch a notification updating background task status -- normal/low priority
 document.ariaNotify( "Background task completed",
-    { "priority":"none",
+    { "priority":"normal",
       "notificationId":"StatusUpdate" }); 
 
 // Dispatch a high priority notification that data may be lost
 document.ariaNotify("Unable to save changes, lost connection to server",
-    { "priority":"important",
+    { "priority":"high",
       "notificationId":"ServerError" }); 
 ```
 
-Assuming the initial low priority string hasn't already started to be acted upon (spoken/brailled), the high priority
+Assuming the initial normal priority string hasn't already started to be acted upon (spoken/brailled), the high priority
 item is guaranteed to be placed ahead of the lower priority and will be processed first, followed by the lower priority
 notification. This ensures that important messages that the user should be aware of are processed and are supplied to
 the user first. 
@@ -250,7 +250,7 @@ document.querySelector("#dataStatus")
             { "notificationId":"statusUpdate" } ); 
 
 document.ariaNotify( " server connection lost ",
-            { "priority":"important",  
+            { "priority":"high",  
               "notificationId":"serverStatus" } ); 
 ```
 
@@ -296,7 +296,7 @@ function simulateProgress() {
   document.querySelector("#progressBar")
           .ariaNotify( "Progress is ${currentValue}", 
             { "notificationId": "progressBar", 
-              "priority":"none",
+              "priority":"normal",
               "interrupt":"none" });
 }
 
@@ -324,7 +324,7 @@ function simulateProgress() {
   document.querySelector("#progressBar")
           .ariaNotify( "Progress is ${currentValue}",
             { "notificationId":"progressBar",
-              "priority":"none",
+              "priority":"normal",
               "interrupt":"all" });
  }
 
@@ -355,7 +355,7 @@ function simulateProgress() {
   document.querySelector("#progressBar")
           .ariaNotify( "Progress is ${currentValue}",
               { "notificationId":"progressBar", 
-                "priority":"none",
+                "priority":"normal",
                 "interrupt":"pending" }); 
 }
 
@@ -377,8 +377,8 @@ notifications to propagate to the top-level browsing context, we will require a 
 ## Relationship to ARIA Live Regions
 There are some similarities between `ariaNotify` and the existing ARIA live regions. This section maps the existing ARIA
 live region configuration attributes to the options available with `ariaNotify`: 
- - `aria-live="assertive"` is the equivalent of `"priority: important"` and `"interrupt: none"`
- - `aria-live="polite"` is the equivalent of `"priority: none"` and `"interrupt: none"`
+ - `aria-live="assertive"` is the equivalent of `"priority: high"` and `"interrupt: none"`
+ - `aria-live="polite"` is the equivalent of `"priority: normal"` and `"interrupt: none"`
 
 Beyond the above, the additional functionality provided by `ariaNotify` is not supported and cannot be mapped back
 directly to ARIA live regions. 
@@ -388,7 +388,7 @@ In the case of browsers that do not yet support `ariaNotify`, we propose the fol
 backend as the existing ARIA live regions: 
  - The message payload for `ariaNotify` is equivalent to the contents of an ARIA live region. 
  - The `notificationId` is dropped entirely. 
- - `"priority: important"` and `"priority: none"` correspond to `aria-live="assertive"` and `aria-live="polite"` ARIA
+ - `"priority: high"` and `"priority: normal"` correspond to `aria-live="assertive"` and `aria-live="polite"` ARIA
  live attributes, respectively. 
  - ARIA live regions do not support interruptibility, so all behavior of `interrupt` defaults to `none`.  
 
@@ -399,15 +399,15 @@ regions:
 #### Example 6 
 ```
 element.ariaNotify("This message is normal.",
-    { "priority": "none",
+    { "priority": "normal",
       "interrupt": "none"}); 
 
 element.ariaNotify("This message should interrupt",
-    { "priority": "none", "interrupt": "all" }); 
+    { "priority": "normal", "interrupt": "all" }); 
 ```
 
 In the above case, when `ariaNotify` is supported, the expected behavior would be for the second notification to silence
-the current one and flush all other queued notifications from element with priority: `"none"`. However, the fallback is
+the current one and flush all other queued notifications from element with priority: `"normal"`. However, the fallback is
 not able to silence or flush existing notifications, as that behavior is not supported in ARIA live regions.  In the
 case that the web browser does not yet support `ariaNotify`, it is the responsibility of the web author to detect and
 fallback to ARIA live regions.  The above conversion may serve as a guide on how to do so. One can detect whether or not

--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -133,7 +133,7 @@ is there a way to know that a screen reader is available at all! Well-designed w
 provide appropriate notifications for accessibility whether or not their users require a screen reader or not. 
 
 #### Example 1
-```
+```js
 // Dispatch a message associated with the document: 
 document.ariaNotify( "John Doe is connected" ); 
 
@@ -177,7 +177,7 @@ To specify a `type`, pass the string as the second parameter.  Alternatively, th
 expressed in an object form with property `type`. For example: 
 
 #### Example 2
-```
+```js
 // Notify of a long-running async task starting and ending 
 document.ariaNotify(
     "Uploading file untitled-1 to the cloud.",
@@ -215,7 +215,7 @@ notifications:
    - Screen reader should add this string to the end of all pending notifications. 
 
 #### Example 3
-```
+```js
 // Dispatch a notification updating background task status -- normal/low priority
 document.ariaNotify( "Background task completed",
     { "priority":"normal",
@@ -233,7 +233,7 @@ notification. This ensures that important messages that the user should be aware
 the user first. 
 
 #### Example 4
-```
+```js
 // User has initiated an action which starts a generation process of data.
 // During the status of the generation, a more critical status needs to be
 // sent to the user 
@@ -286,7 +286,7 @@ scenario (a progress bar which reports its status at every percent increment):
 #### Example 5.1
 `interrupt:none` - Every progress bar percentage from 1% to 100% will be spoken. 
 
-```
+```js
 let percent = 0; 
 function simulateProgress() { 
   percent += 1; 
@@ -313,7 +313,7 @@ Because the percentage is likely updating before each percentage fully speaks, t
 first part of each/some percentage until the last is processed where the user will hear the full string "Progress is
 100". 
 
-```
+```js
 let percent = 0; 
 function simulateProgress() { 
   percent += 1; 
@@ -344,7 +344,7 @@ skipped. A slower speech rate will cause more percentages to be ignored. A faste
 percentages to be spoken. When the current percentage fully speaks, the next percentage that was allowed to be held will
 speak, and the process will repeat. Finally, the last percentage "Progress is 100" will be spoken.  
 
-```
+```js
 let percent = 0; 
 function simulateProgress() { 
   percent += 1; 
@@ -397,7 +397,7 @@ to achieve similar behavior. There are cases where we will not be able to get th
 regions:
 
 #### Example 6 
-```
+```js
 element.ariaNotify("This message is normal.",
     { "priority": "normal",
       "interrupt": "none"}); 
@@ -413,7 +413,7 @@ case that the web browser does not yet support `ariaNotify`, it is the responsib
 fallback to ARIA live regions.  The above conversion may serve as a guide on how to do so. One can detect whether or not
 `ariaNotify` is supported by checking if the method exists on the document or element in question: 
 
-```
+```js
 if ("ariaNotify" in element) { 
   element.ariaNotify(...); 
 } 
@@ -457,27 +457,21 @@ Opportunities exist to mitigate against these possibilities:
  primitives to limit usage of this API to only actions taken by the user. 
 
 ## Future considerations 
-1. `ariaNotify` can be extended in the future to handle more functionality as needs arise. Two possible examples are
-provided below.There may be a need for a web author to supply a Braille specific string separate from the speech string.
+`ariaNotify` can be extended in the future to handle more functionality as needs arise. 
+### Braille and Pronunciations
+There may be a need for a web author to supply a Braille specific string separate from the speech string. For example, an author could supply "3 stars" as the speech string to indicate a retail item's rating. However, to better map within a Braille display, the author could supply `***` as a Braille alternative string. The API could easily be extended by adding another optional property for Braille strings. For example: 
 
-    For example, an author could supply "3 stars" as the speech string to indicate a retail item's rating. However, to better map within a Braille display, the author could supply `***` as a Braille alternative string. 
-
-    The API could easily be extended by adding another optional property for Braille strings. For example: 
-
-```
+```js
 document.ariaNotify( "3 stars", {"braille":"***"} );
 ```
 
-2. There may also be a use case where an author would want to allow the speech string to be marked up to guarantee a
+There may also be a use case where an author would want to allow the speech string to be marked up to guarantee a
 specific pronunciation. This can be useful in cases where the speech engine may not produce the best experience for the
 user.
 
-    For example, maybe you would like "911" pronounce as "9 1 1" in some cases. Or in a spreadsheet, you may want to hear "a
-1" spoken with a long "a" sound instead of a short "a" sound (i.e. "ay 1" as opposed to  "uh 1").  
+For example, maybe you would like "911" pronounce as "9 1 1" in some cases. Or in a spreadsheet, you may want to hear "a 1" spoken with a long "a" sound instead of a short "a" sound (i.e. "ay 1" as opposed to  "uh 1"). The API could easily be extended by adding another property for strings marked up with, say, SSML: 
 
-    The API could easily be extended by adding another property for strings marked up with, say, SSML: 
-
-```
+```js
 document.ariaNotify( "911", {"SSML":"<say-as
 interpret-as=\x22\"""digits\x22""">911" });
 ``` 

--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -105,7 +105,6 @@ beyond the immediate effect of the primary action.
    - solves the consistency and predictability problems of live regions 
  - Provide a design framework for improvements to live regions as a "declarative version" of the notification API. 
    - removes guesswork on what to speak from a DOM node by providing an exact string 
-   - provides context of what the string represents 
 
 ## Proposed Solution 
 A new API, `ariaNotify`, enables content authors to directly tell a screen reader what to read. The behavior would be
@@ -184,7 +183,7 @@ notifications to propagate to the top-level browsing context, we will require a 
 ## Relationship to ARIA Live Regions
 There are some similarities between `ariaNotify` and the existing ARIA live regions. Some functionality provided by `ariaNotify` is not supported and cannot be mapped back directly to ARIA live regions. 
 
-In the case of browsers that do not yet support `ariaNotify`, we propose the following fallback mechanism using the same
+In the case of operating systems that do not yet support `ariaNotify`, we propose the following fallback mechanism using the same
 backend as the existing ARIA live regions: 
  - The message payload for `ariaNotify` is equivalent to the contents of an ARIA live region. 
  - `"priority: high"` corresponds to ARIA live's `aria-live="assertive"` 
@@ -354,7 +353,7 @@ The only difference between the three snippets is the `interrupt` setting. Each 
 experience difference for the user. 
 
 ##### Fallback
-In the case of browsers that do not yet support `ariaNotify`, ARIA live regions do not support interruptibility, so all behavior of `interrupt` defaults to `none`. 
+In the case of operating systems that do not yet support `ariaNotify`, ARIA live regions do not support interruptibility, so all behavior of `interrupt` defaults to `none`. 
 
 The addition of `interrupt` would mean that there is no exact mapping of `ariaNotify` back to ARIA live regions, and our proposal reflects a best effort
 to achieve similar behavior. There are cases where we will not be able to get the intended behavior using ARIA live
@@ -456,7 +455,7 @@ document.ariaNotify( " server connection lost ",
 As content is being generated, the user is informed of that status. When something more serious occurs, such as losing server access, the server error is prioritized above any pending status updates. Screen readers can choose to offer settings for users to manage specific types, like supressing minor `statusUpdate` notifications entirely.
 
 #### Fallback 
-In the case of browsers that do not yet support `ariaNotify`, `type` is dropped entirely when falling back to ARIA live regions. 
+In the case of operating systems that do not yet support `ariaNotify`, `type` is dropped entirely when falling back to ARIA live regions. 
 
 #### Open Issue - Predefined types 
 The use of `type` give the screen reader contextual information regarding the notification which allows for


### PR DESCRIPTION
Sweeping changes based on ARIA WG discussions:
- Renamed `priority` values - `none` to `normal` and `important` to `high`.
- Renamed `notificationId` to `type` (doesn't seem like there was consensus here, but that `type` was a step in the right direction).
- Made `sandbox` property name more clear.
- Moved `interrupt` to future considerations.
- Moved `type` to future considerations.
- Adjusted all examples and references to make sense based on everything above.
- Added myself as an author.

I noticed a bit too late that this file had linebreaks at 120 characters. I inadvertently removed some of those and didn't try to keep consistent with that (it's markdown not C++ 😅), so sorry for any review pain that causes. It's probably worth looking at the individual commit diffs for review to remove the noise of the unrelated parts, specifically the "Move interrupt and type to future options." commit has the most major changes.

One lingering note I think we might need to fix - Moving `interrupt` to the future means we probably need to expand the ARIA live region fallback for that to handle the three cases - no `ariaNotify`, `ariaNotify` without `interrupt`, and `ariaNotify` with `interrupt`.
