### PR TITLE
Add explainer for ElementInternals.type

### DIFF
--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -35,6 +35,23 @@ If `elementInternals.type` is assigned any other value, a ["NotSupportedError"](
 
 `elementInternals.type` should only be set once. If `elementInternals.type` has a non-empty string value and is attempted to be set again, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown. This works similar to how [`attachInternals` throws an error if called on an element more than once](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals:~:text=If%20this%27s%20attached%20internals%20is%20non%2Dnull%2C%20then%20throw%20an%20%22NotSupportedError%22%20DOMException).
 
+Setting `elementInternal.type` allows the custom element to support additional attributes, the full list for each type is provided in the sub-sections below. If any of the properties have been set prior to setting `elementInternals.type`, the attribute will be "reset" to the default state for that type. Below is an example showcasing this with the `disabled` attribute.
+
+```js
+    class CustomButton extends HTMLElement {
+        static formAssociated = true;
+
+        constructor() {
+            super();
+            this.disabled = true;
+            this.internals_ = this.attachInternals();
+            this.internals_.type = 'button';
+            console.log(this.disabled)  // logs `false`
+        }
+    }
+    customElements.define('custom-button', CustomButton);
+```
+
 ### `elementInternals.type = 'button'`
 When `elementInternals.type = 'button'` is set in a custom element's constructor, the custom element will gain support for the attributes listed below.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
@@ -144,6 +161,9 @@ When `elementInternals.type` is set, the custom element will be assigned the sam
 
 ### `elementInternals.type` does not conflict with `extends`
 Per spec, [`attachInternals`](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals) cannot be called on custom elements that are defined with `extends`. Therefore, it is not possible to create a custom element that is defined with `extends` and also sets `elementInternals.type`.
+
+### `elementInternals.type` does not change element appearance
+Setting `elementInternals.type` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles from the native element.
 
 ## Alternatives considered
 

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -125,11 +125,15 @@ Below is an example showcasing a custom submit button being used to submit a for
 
 If the `disabled` attribute is set on a custom submit button, it cannot be activated and thus cannot submit forms.
 
+Note that a custom submit button needs to be defined as a [form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) in order to be able to submit forms. This is done by including `static formAssociated = true;` in its definition.
+
 ### `elementInternals.type = 'reset'`
 Custom elements with `elementInternals.type = 'reset'` set will support the following attributes.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
+
+Similar to custom submit buttons, custom reset buttons also need to defined as [form-associated](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) in order to be able to reset forms.
 
 ### `elementInternals.type = 'label'`
 Custom elements with `elementInternals.type = 'label'` set will support the following attributes.

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -28,14 +28,21 @@ Web component authors often seek to create custom elements that inherit the beha
 ## Proposed Approach: add `type` property to `ElementInternals`
 
 The `ElementInternals` interface currently give web developers a way to participate in HTML forms and integrate with the accessibility OM. These capabilities can be extended to also support customizable built-ins by adding a `type` property, which can be set to string values that represent native element types. The initial set of `type` values being proposed are listed below, though more may be added in the future.
-  - `button` (for [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button))
-  - `submit` (for [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit))
-  - `reset` (for [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset))
-  - `label` (for [label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element))
+- `button` (for [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button))
+- `submit` (for [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit))
+- `reset` (for [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset))
+- `label` (for [label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element))
 
-### Example #1: Custom button
+### `elementInternals.type = 'button'`
 
-Below is an example showcasing a custom button definition and how the custom button can then be declaratively created and used as a popup invoker. When the custom button is activated, ex. via a click, `div id="my-popover` will be shown as a popover.
+`elementInternals.type = 'button'` can be set in a custom element constructor to give the custom element native button like behavior. Specifically, the custom element will support the attributes listed below.
+- [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
+- [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
+- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
+- [`popovertarget`](https://html.spec.whatwg.org/multipage/popover.html#attr-popovertarget)
+- [`popovertargetaction`](https://html.spec.whatwg.org/multipage/popover.html#attr-popovertargetaction)
+
+Below is an example showcasing a custom button being used as a popup invoker. When the custom button is activated, ex. via a click, `div id="my-popover` will be shown as a popover.
 
 ```js
     class CustomButton extends HTMLElement {
@@ -54,9 +61,29 @@ Below is an example showcasing a custom button definition and how the custom but
     <div id="my-popover" popover>This is popover content.</div>
 ```
 
-### Example #2: Custom submit button
+Just like with native buttons, if the `disabled` attribute is set, a custom button cannot be activated and thus cannot invoke popovers.
 
-Below is an example showcasing a custom submit button definition and how the custom submit button can then be declaratively created and used to submit a form. When the custom button is activated, ex. via a click, the form will be submitted and the page will navigate.
+### `elementInternals.type = 'submit'`
+
+Custom elements with `elementInternals.type = 'submit'` set will support the following attributes.
+- [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
+- [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
+- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
+- [`formAction`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formaction)
+- [`formEnctype`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formenctype)
+- [`formMethod`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formmethod)
+- [`formNoValidate`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formnovalidate)
+- [`formTarget`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formtarget)
+- [`name`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name)
+- [`value`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-value)
+- [`willValidate`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate)
+- [`validity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity)
+- [`validationMessage`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage)
+- [`checkValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity)
+- [`reportValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity)
+- [`setCustomValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity)
+
+Below is an example showcasing a custom submit button being used to submit a form. When the custom button is activated, ex. via a click, the form will be submitted and the page will navigate.
 
 ```js
     class CustomSubmitButton extends HTMLElement {
@@ -76,9 +103,23 @@ Below is an example showcasing a custom submit button definition and how the cus
     </form>
 ```
 
-### Example #3: Custom label
+If the `disabled` attribute is set, a custom button cannot be activated and thus cannot submit the form.
 
-Below is an example showcasing how to create a custom label definition and how the custom label can then be declaratively created and used to label a checkbox. When the custom label is activated, ex. via a click, the checkbox is also activated, resulting in its state changing to checked.
+### `elementInternals.type = 'reset'`
+
+Custom elements with `elementInternals.type = 'submit'` set will support the following attributes.
+- [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
+- [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
+- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
+
+### `elementInternals.type = 'label'`
+
+Custom elements with `elementInternals.type = 'label'` set will support the following attributes.
+- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
+- [`for`](https://html.spec.whatwg.org/multipage/forms.html#dom-label-htmlfor)
+- [`control`](https://html.spec.whatwg.org/multipage/forms.html#dom-label-control)
+
+Below is an example showcasing a custom label being used to label a checkbox. When the custom label is activated, ex. via a click, the checkbox is also activated, resulting in its state changing to checked.
 
 ```js
     class CustomLabel extends HTMLElement {
@@ -97,29 +138,9 @@ Below is an example showcasing how to create a custom label definition and how t
    <input type='checkbox' id='my-checkbox' />
 ```
 
-### Dependencies on non-stable features
+### Resolving ARIA roles
 
-[If your proposed solution depends on any other features that haven't been either implemented by
-multiple browser engines or adopted by a standards working group (that is, not just a W3C community
-group), list them here.]
 
-### Solving [goal 1] with this approach
-
-```js
-// Provide example code - not IDL - demonstrating the design of the feature.
-
-// If this API can be used on its own to address a user need,
-// link it back to one of the scenarios in the goals section.
-
-// If you need to show how to get the feature set up
-// (initialized, or using permissions, etc.), include that too.
-```
-
-### Solving [goal 2] with this approach
-
-[If some goals require a suite of interacting APIs, show how they work together to achieve the goals.]
-
-[etc.]
 
 ## Alternatives considered
 

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -41,6 +41,7 @@ The `ElementInternals` interface currently give web developers a way to particip
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
 - [`popovertarget`](https://html.spec.whatwg.org/multipage/popover.html#attr-popovertarget)
 - [`popovertargetaction`](https://html.spec.whatwg.org/multipage/popover.html#attr-popovertargetaction)
+- [`interesttarget`](https://github.com/whatwg/html/pull/11006/files#:~:text=span%3E%20the%20%3Ccode%20data%2Dx%3D%22attr%2Dinteresttarget%22%3E-,interesttarget,-%3C/code%3E%20attribute.%3C/p%3E) - [currently experimental in Chromium](https://groups.google.com/a/chromium.org/g/blink-dev/c/LLgsMjTzmAY/m/5GUjSYC2AQAJ)
 
 Below is an example showcasing a custom button being used as a popup invoker. When the custom button is activated, ex. via a click, `div id="my-popover` will be shown as a popover.
 
@@ -82,6 +83,8 @@ Custom elements with `elementInternals.type = 'submit'` set will support the fol
 - [`checkValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity)
 - [`reportValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity)
 - [`setCustomValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity)
+- [`name`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name)
+- [`value`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-value)
 
 Below is an example showcasing a custom submit button being used to submit a form. When the custom button is activated, ex. via a click, the form will be submitted and the page will navigate.
 
@@ -138,9 +141,9 @@ Below is an example showcasing a custom label being used to label a checkbox. Wh
    <input type='checkbox' id='my-checkbox' />
 ```
 
-### Resolving ARIA roles
+### Order of precedence for used values: Element properties > `ElementInternals` properties > default properties via `elementInternals.type`
 
-
+When `elementInternals.type` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `elementInternals.type = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternal.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
 
 ## Alternatives considered
 
@@ -150,11 +153,6 @@ Both `extends` and `is` are supported in Firefox and Chromium-based browsers tod
 
 The `elementInternals.type` proposal addresses many of the limitations with `extends`/`is`, including allowing customized built-ins to support shadow DOM. The proposal also has support from the WHATWG and members from multiple browser (including Safari) as noted by a WG resolution here: https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455.
 
-
-## Accessibility, Privacy, and Security Considerations
-
-[Highlight any accessibility, security, and privacy implications that have been taken into account
-during the design process.]
 
 ## Stakeholder Feedback / Opposition
 

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -115,7 +115,7 @@ If the `disabled` attribute is set on a custom submit button, it cannot be activ
 
 ### `elementInternals.type = 'reset'`
 
-Custom elements with `elementInternals.type = 'submit'` set will support the following attributes.
+Custom elements with `elementInternals.type = 'reset'` set will support the following attributes.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -35,7 +35,7 @@ If `elementInternals.type` is assigned any other value, a ["NotSupportedError"](
 
 `elementInternals.type` should only be set once. If `elementInternals.type` has a non-empty string value and is attempted to be set again, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown. This works similar to how [`attachInternals` throws an error if called on an element more than once](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals:~:text=If%20this%27s%20attached%20internals%20is%20non%2Dnull%2C%20then%20throw%20an%20%22NotSupportedError%22%20DOMException).
 
-Setting `elementInternal.type` allows the custom element to support additional attributes, the full list for each type is provided in the sub-sections below. If any of the properties have been set prior to setting `elementInternals.type`, the attribute will be "reset" to the default state for that type. Below is an example showcasing this with the `disabled` attribute.
+Setting `elementInternal.type` allows the custom element to support additional attributes. The full list for each type is provided in the sub-sections below. If any of the properties have been set prior to setting `elementInternals.type`, the attribute will be "reset" to the default state for that type. Below is an example showcasing this with the `disabled` attribute.
 
 ```js
     class CustomButton extends HTMLElement {
@@ -46,7 +46,7 @@ Setting `elementInternal.type` allows the custom element to support additional a
             this.disabled = true;
             this.internals_ = this.attachInternals();
             this.internals_.type = 'button';
-            console.log(this.disabled)  // logs `false`
+            console.log(this.disabled);  // logs `false`
         }
     }
     customElements.define('custom-button', CustomButton);

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -1,16 +1,14 @@
 # ElementInternals.type
 
 ## Authors:
-
 - [Sanket Joshi](https://github.com/sanketj)
 - [Alex Keng](https://github.com/alexkeng)
 - [Chris Holt](https://github.com/chrisdholt)
 
 ## Participate
-  - [OpenUI issue tracking initial discussions and WHATWG resolution to accept `elementInternals.type = 'button'`](https://github.com/openui/open-ui/issues/1088)
+- [OpenUI issue tracking initial discussions and WHATWG resolution to accept `elementInternals.type = 'button'`](https://github.com/openui/open-ui/issues/1088)
 
 ## Introduction
-
 Web component authors often want to create custom elements that inherit the behaviors and properties of native HTML elements. These types of custom elements are referred to as "customized built-in elements" or just "customized built-ins". By customizing built-in elements, custom elements can leverage the built-in functionality of standard elements while extending their capabilities to meet specific needs. Some of the use cases enabled by customized built-ins are listed below.
 
 - Custom buttons can provide unique styles and additional functionality, such as split or toggle button semantics, while still maintaining [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button) behavior such as being a [popover invoker](https://html.spec.whatwg.org/multipage/popover.html#popoverinvokerelement).
@@ -18,17 +16,14 @@ Web component authors often want to create custom elements that inherit the beha
 - Custom labels can provide additional functionality, such as tooltips and icons, while still supporting associations with [labelable elements](https://html.spec.whatwg.org/multipage/forms.html#category-label) via the `for` attribute or nesting a labelable element inside the custom label.
 
 ### Goals
-
 - A solution for customized built-in elements that provides an improvement over `extends`/`is`, in terms of interoperability and functionality.
 - Supporting as many as customized built-in use cases as possible, though not necessarily all at once. Support for more `type` values can be added over time.
 
 ### Non-goals
-
 - Deprecation of `extends`/`is`. This is something that can be considered independently, once `elementInternals.type` addresses developer needs sufficiently.
 - A declarative version of `elementInternals.type`. This requires finding a general solution for declarative custom elements with declarative `elementInternals`. This is a broader problem that should be explored separately.
 
 ## Proposal: add `type` property to `ElementInternals`
-
 The `ElementInternals` interface gives web developers a way to participate in HTML forms and integrate with the accessibility OM. This will be extended to support the creation of customized built-ins by adding a `type` property, which can be set to string values that represent native element types. The initial set of `type` values being proposed are listed below. Support for additional values may be added in the future.
 - `'' (empty string)` - this is the default value, indicating the custom element is not a customized built-in
 - `button` - for [button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button) like behavior
@@ -38,8 +33,9 @@ The `ElementInternals` interface gives web developers a way to participate in HT
 
 If `elementInternals.type` is assigned any other value, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown.
 
-### `elementInternals.type = 'button'`
+`elementInternals.type` should only be set once. If `elementInternals.type` has a non-empty string value and is attempted to be set again, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown. This works similar to how [`attachInternals` throws an error if called on an element more than once](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals:~:text=If%20this%27s%20attached%20internals%20is%20non%2Dnull%2C%20then%20throw%20an%20%22NotSupportedError%22%20DOMException).
 
+### `elementInternals.type = 'button'`
 When `elementInternals.type = 'button'` is set in a custom element's constructor, the custom element will gain support for the attributes listed below.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
@@ -70,7 +66,6 @@ Below is an example showcasing a custom button being used as a popup invoker. Wh
 Like with native buttons, if the `disabled` attribute is set, a custom button cannot be activated and thus cannot invoke popovers.
 
 ### `elementInternals.type = 'submit'`
-
 Custom elements with `elementInternals.type = 'submit'` set will support the following attributes.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
@@ -114,14 +109,12 @@ Below is an example showcasing a custom submit button being used to submit a for
 If the `disabled` attribute is set on a custom submit button, it cannot be activated and thus cannot submit forms.
 
 ### `elementInternals.type = 'reset'`
-
 Custom elements with `elementInternals.type = 'reset'` set will support the following attributes.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
 
 ### `elementInternals.type = 'label'`
-
 Custom elements with `elementInternals.type = 'label'` set will support the following attributes.
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
 - [`for`](https://html.spec.whatwg.org/multipage/forms.html#dom-label-htmlfor)
@@ -147,7 +140,6 @@ Below is an example showcasing a custom label being used to label a checkbox. Wh
 ```
 
 ### Order of precedence for used values: Element properties > `ElementInternals` properties > default properties via `elementInternals.type`
-
 When `elementInternals.type` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `elementInternals.type = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternal.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
 
 ### `elementInternals.type` does not conflict with `extends`

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -123,9 +123,9 @@ Below is an example showcasing a custom submit button being used to submit a for
     </form>
 ```
 
-If the `disabled` attribute is set on a custom submit button, it cannot be activated and thus cannot submit forms.
-
 Note that a custom submit button needs to be defined as a [form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) in order to be able to submit forms. This is done by including `static formAssociated = true;` in its definition.
+
+If the `disabled` attribute is set on a custom submit button, it cannot be activated and thus cannot submit forms.
 
 ### `elementInternals.type = 'reset'`
 Custom elements with `elementInternals.type = 'reset'` set will support the following attributes.

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -1,0 +1,91 @@
+# ElementInternals.type
+
+## Authors:
+
+- [Sanket Joshi](https://github.com/sanketj)
+- [Alex Keng](https://github.com/alexkeng)
+
+## Participate
+  - [OpenUI issue tracking initial discussions and WHATWG resolution to accept `elementInternals.type = 'button'`](https://github.com/openui/open-ui/issues/1088)
+
+## Introduction
+
+Web component authors often seek to create custom elements that inherit the behaviors and properties of native HTML elements (ie. customized built-in elements). This allows them to leverage the built-in functionality of standard elements while extending their capabilities to meet specific needs. Some of the use cases enabled by customized built-ins are listed below.
+
+- Custom buttons can provide unique styles and additional functionality, such as split or toggle button semantics, while still maintaining [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button) behavior such as being a [popover invoker](https://html.spec.whatwg.org/multipage/popover.html#popoverinvokerelement).
+- Custom buttons can extend native [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit) behavior so that the custom button can implicitly [submit forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit) when activated. Similarly, custom buttons that extend native [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset) behavior can implicitly [reset forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset) when activated.
+- Custom labels can provide additional functionality, such as tooltips and icons, while still supporting associations with [labelable elements](https://html.spec.whatwg.org/multipage/forms.html#category-label) via the `for` attribute.
+
+### Goals
+
+- [A bulleted list of goals can help with comparing proposed solutions.]
+
+### Non-goals
+
+[If there are "adjacent" goals which may appear to be in scope but aren't,
+enumerate them here. This section may be fleshed out as your design progresses and you encounter necessary technical and other trade-offs.]
+
+## Proposed Approach
+
+[Explain the proposed solution or approach to addressing the identified problem.
+Do not include WebIDL in this section.
+Show example code using your approach.]
+
+[Where necessary, provide links to longer explanations of the relevant pre-existing concepts and API.
+If there is no suitable external documentation, you might like to provide supplementary information as an appendix in this document, and provide an internal link where appropriate.]
+
+[If this is already specced, link to the relevant section of the spec.]
+
+[If spec work is in progress, link to the PR or draft of the spec.]
+
+### Dependencies on non-stable features
+
+[If your proposed solution depends on any other features that haven't been either implemented by
+multiple browser engines or adopted by a standards working group (that is, not just a W3C community
+group), list them here.]
+
+### Solving [goal 1] with this approach
+
+```js
+// Provide example code - not IDL - demonstrating the design of the feature.
+
+// If this API can be used on its own to address a user need,
+// link it back to one of the scenarios in the goals section.
+
+// If you need to show how to get the feature set up
+// (initialized, or using permissions, etc.), include that too.
+```
+
+### Solving [goal 2] with this approach
+
+[If some goals require a suite of interacting APIs, show how they work together to achieve the goals.]
+
+[etc.]
+
+## Alternatives considered
+
+A partial solution for this problem already exists today. Authors can specify the `extends` option when [defining a custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define). Authors can then use the `is` attribute to give a built-in element a custom name, thereby turning it into a customizable built-in element.
+
+Both `extends` and `is` are supported in Firefox and Chromium-based browsers today. However, this solution does have limitations, such as not being able to attach shadow trees to (most) customizable built-in elements. Citing these limitations, Safari doesn't plan to support customizable built-ins in this way and have shared their objections here: https://github.com/WebKit/standards-positions/issues/97#issuecomment-1328880274. As such, `extends` and `is` are not on a path to full interoperability today.
+
+The `elementInternals.type` proposal addresses many of the limitations with `extends`/`is`, including allowing customized built-ins to support shadow DOM. The proposal also has support from the WHATWG and members from multiple browser (including Safari) as noted by a WG resolution here: https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455.
+
+
+## Accessibility, Privacy, and Security Considerations
+
+[Highlight any accessibility, security, and privacy implications that have been taken into account
+during the design process.]
+
+## Stakeholder Feedback / Opposition
+
+- Chromium : Positive
+- WebKit : Positive based on https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455
+- Gecko : No official signal, but no objections shared in the discussion here: https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455
+
+[WHATWG resolution to accept `elementInternals.type = 'button'`](https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455)
+
+## References & acknowledgements
+
+Many thanks for valuable feedback and advice from:
+
+- [Chris Holt](https://github.com/chrisdholt)

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -123,8 +123,6 @@ Below is an example showcasing a custom submit button being used to submit a for
     </form>
 ```
 
-Note that a custom submit button needs to be defined as a [form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) in order to be able to submit forms. This is done by including `static formAssociated = true;` in its definition.
-
 If the `disabled` attribute is set on a custom submit button, it cannot be activated and thus cannot submit forms.
 
 ### `elementInternals.type = 'reset'`
@@ -132,8 +130,6 @@ Custom elements with `elementInternals.type = 'reset'` set will support the foll
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
-
-Similar to custom submit buttons, custom reset buttons also need to defined as [form-associated](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) in order to be able to reset forms.
 
 ### `elementInternals.type = 'label'`
 Custom elements with `elementInternals.type = 'label'` set will support the following attributes.
@@ -161,13 +157,16 @@ Below is an example showcasing a custom label being used to label a checkbox. Wh
 ```
 
 ### Order of precedence for used values: Element properties > `ElementInternals` properties > default properties via `elementInternals.type`
-When `elementInternals.type` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `elementInternals.type = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternal.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
+When `elementInternals.type` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `elementInternals.type = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternals.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
 
 ### `elementInternals.type` does not conflict with `extends`
 Per spec, [`attachInternals`](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals) cannot be called on custom elements that are defined with `extends`. Therefore, it is not possible to create a custom element that is defined with `extends` and also sets `elementInternals.type`.
 
 ### `elementInternals.type` does not change element appearance
 Setting `elementInternals.type` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles from the native element.
+
+### Customized built-ins must be [form-associated](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) to participate in forms
+Today, custom elements need to be defined as [form-associated](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) to participate in forms. This is done by including `static formAssociated = true;` in its definition. Customized built-ins created by setting `elementInternals.type` will also need to be defined with `static formAssociated = true;` to participate in forms.
 
 ## Alternatives considered
 

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-Web component authors often want to create custom elements that inherit the behaviors and properties of native HTML elements (ie. "customized built-in elements" or just "customized built-ins"). This allows them to leverage the built-in functionality of standard elements while extending their capabilities to meet specific needs. Some of the use cases enabled by customized built-ins are listed below.
+Web component authors often want to create custom elements that inherit the behaviors and properties of native HTML elements. These types of custom elements are referred to as "customized built-in elements" or just "customized built-ins". By customizing built-in elements, custom elements can leverage the built-in functionality of standard elements while extending their capabilities to meet specific needs. Some of the use cases enabled by customized built-ins are listed below.
 
 - Custom buttons can provide unique styles and additional functionality, such as split or toggle button semantics, while still maintaining [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button) behavior such as being a [popover invoker](https://html.spec.whatwg.org/multipage/popover.html#popoverinvokerelement).
 - Custom buttons can extend native [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit) behavior so that the custom button can implicitly [submit forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit). Similarly, custom buttons that extend native [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset) behavior can implicitly [reset forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset).
@@ -40,7 +40,7 @@ If `elementInternals.type` is assigned any other value, a ["NotSupportedError"](
 
 ### `elementInternals.type = 'button'`
 
-`elementInternals.type = 'button'` can be set in a custom element constructor to give the custom element native button like behavior. Specifically, the custom element will support the attributes listed below.
+When `elementInternals.type = 'button'` is set in a custom element's constructor, the custom element will gain support for the attributes listed below.
 - [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
 - [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
 - [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
@@ -67,7 +67,7 @@ Below is an example showcasing a custom button being used as a popup invoker. Wh
     <div id="my-popover" popover>This is popover content.</div>
 ```
 
-Just like with native buttons, if the `disabled` attribute is set, a custom button cannot be activated and thus cannot invoke popovers.
+Like with native buttons, if the `disabled` attribute is set, a custom button cannot be activated and thus cannot invoke popovers.
 
 ### `elementInternals.type = 'submit'`
 

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -13,7 +13,7 @@
 Web component authors often seek to create custom elements that inherit the behaviors and properties of native HTML elements (ie. customized built-in elements). This allows them to leverage the built-in functionality of standard elements while extending their capabilities to meet specific needs. Some of the use cases enabled by customized built-ins are listed below.
 
 - Custom buttons can provide unique styles and additional functionality, such as split or toggle button semantics, while still maintaining [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button) behavior such as being a [popover invoker](https://html.spec.whatwg.org/multipage/popover.html#popoverinvokerelement).
-- Custom buttons can extend native [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit) behavior so that the custom button can implicitly [submit forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit) when activated. Similarly, custom buttons that extend native [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset) behavior can implicitly [reset forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset) when activated.
+- Custom buttons can extend native [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit) behavior so that the custom button can implicitly [submit forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit). Similarly, custom buttons that extend native [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset) behavior can implicitly [reset forms](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset).
 - Custom labels can provide additional functionality, such as tooltips and icons, while still supporting associations with [labelable elements](https://html.spec.whatwg.org/multipage/forms.html#category-label) via the `for` attribute or nesting a labelable element inside the custom label.
 
 ### Goals
@@ -25,9 +25,9 @@ Web component authors often seek to create custom elements that inherit the beha
 
 - Deprecation of `extends`/`is`. This is something that should be considered independently, once `elementInternals.type` addresses developer needs sufficiently.
 
-## Proposed Approach: add `type` property to `ElementInternals`
+## Proposal: add `type` property to `ElementInternals`
 
-The `ElementInternals` interface currently give web developers a way to participate in HTML forms and integrate with the accessibility OM. These capabilities can be extended to also support customizable built-ins by adding a `type` property, which can be set to string values that represent native element types. The initial set of `type` values being proposed are listed below, though more may be added in the future.
+The `ElementInternals` interface gives web developers a way to participate in HTML forms and integrate with the accessibility OM. This will be extended to support the creation of customizable built-ins by adding a `type` property, which can be set to string values that represent native element types. The initial set of `type` values being proposed are listed below. More values may be supported in the future.
 - `button` (for [native button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button))
 - `submit` (for [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit))
 - `reset` (for [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset))
@@ -149,9 +149,9 @@ When `elementInternals.type` is set, the custom element will be assigned the sam
 
 A partial solution for this problem already exists today. Authors can specify the `extends` option when [defining a custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define). Authors can then use the `is` attribute to give a built-in element a custom name, thereby turning it into a customizable built-in element.
 
-Both `extends` and `is` are supported in Firefox and Chromium-based browsers today. However, this solution does have limitations, such as not being able to attach shadow trees to (most) customizable built-in elements. Citing these limitations, Safari doesn't plan to support customizable built-ins in this way and have shared their objections here: https://github.com/WebKit/standards-positions/issues/97#issuecomment-1328880274. As such, `extends` and `is` are not on a path to full interoperability today.
+Both `extends` and `is` are supported in Firefox and Chromium-based browsers today. However, this solution has limitations, such as not being able to attach shadow trees to (most) customizable built-in elements. Citing these limitations, Safari doesn't plan to support customizable built-ins in this way and have shared their objections here: https://github.com/WebKit/standards-positions/issues/97#issuecomment-1328880274. As such, `extends` and `is` are not on a path to full interoperability today.
 
-The `elementInternals.type` proposal addresses many of the limitations with `extends`/`is`, including allowing customized built-ins to support shadow DOM. The proposal also has support from the WHATWG and members from multiple browser (including Safari) as noted by a WG resolution here: https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455.
+The `elementInternals.type` proposal addresses many of the limitations with `extends`/`is`, including allowing customized built-ins to support shadow DOM. The proposal also has support from the WHATWG and multiple browser vendors (including Safari) as noted by a WG resolution here: https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455.
 
 
 ## Stakeholder Feedback / Opposition


### PR DESCRIPTION
The `elementInternals.type` API was initially proposed here: https://github.com/openui/open-ui/issues/1088#issuecomment-2366092981 and accepted by the WHATWG at TPAC. This API provides an improvement over the existing solution for customizable built-ins, ie. `extends`/`is`, both in terms of interop (support from Safari) and functionality (shadow trees can be attached to customizable built-ins).

This PR captures this proposal in explainer form, and supports `button`, `submit`, `reset` and `label` as type values.