### PR TITLE
Adds implementor criteria

### DIFF
--- a/WebInstall/explainer.md
+++ b/WebInstall/explainer.md
@@ -230,7 +230,7 @@ In the case that the `navigator.install` method is invoked to install an applica
 * The promise rejects otherwise, with an `AbortError`.
 
 ## Installability criteria & Web app manifest `id`
-To install content using the Web Install API, the _document being installed_ must have a manifest file. In an ideal scenario the manifest file has an `id` key/value defined, but in either case the processed web app manifest `id` will serve as the installed application's unique identifier. 
+To install content using the Web Install API, the _document being installed_ must have a manifest file. In an ideal scenario the manifest file has an `id` key/value defined, but in either case the processed web app manifest `id` will serve as the installed application's unique identifier. Any other requirement to pass 'installability criteria' is up to each implementor. 
 
 The importance of `id`s for installed content is to avoid cases where multiple *same* apps are installed with no way to update them. More details can be found in [this document](https://docs.google.com/document/d/19dad0LnqdvEhK-3GmSaffSGHYLeM0kHQ_v4ZRNBFgWM/edit#heading=h.koe6r7c5fhdg).
 


### PR DESCRIPTION
- clarifies that the only required field is `id`, anything else is up to the implementor.