### PR TITLE
Add link to the Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)


### PR DESCRIPTION
All Microsoft projects are automatically covered by the Code of Conduct and the Issue Resolution Process. Adding a link to the Code of Conduct. This is based upon the current CODE_OF_CONDUCT.md version as described here: https://github.com/microsoft/repo-templates/blob/main/shared/CODE_OF_CONDUCT.md