### PR TITLE
Improve text on the resources that are not downloaded.

### DIFF
--- a/ResourceTimingInitiatorInfo/explainer.md
+++ b/ResourceTimingInitiatorInfo/explainer.md
@@ -60,7 +60,7 @@ There are a number of advantages to this approach.
 - It simplifies implementation.
 
 ### 3. UA only partially implements the `initiator Info`.
-When the `initiator info` is missing for some resources, the partial resource dependency information is still useful. Therefore, a UA can release a particial `initiator info` implementation and make improvements later.
+When the `initiator info` is missing for some resources, the partial resource dependency information is still useful. Therefore, a UA can release a partial `initiator info` implementation and make improvements later.
 
 
 ## Alternatives considered

--- a/ResourceTimingInitiatorInfo/explainer.md
+++ b/ResourceTimingInitiatorInfo/explainer.md
@@ -47,7 +47,7 @@ An empty `initiatorUrl` indicates the `initiator info` is missing. There are a n
 A main page can be loaded according to the user navigation. For the main page, `initiator` doesn't exist.
 
 ### 2. Resources may not be downloaded from network.
-Resources can be cached, or handled by services workers, instead of being downloaded from network.They still appear in `PerformanceResourceTiming`. Such resources are not part of the resource dependency tree, and they are not relevant to the content delivery optimization.
+Resources can be cached, or handled by service workers, instead of being downloaded from network. They still appear in `PerformanceResourceTiming`. Such resources are not part of the resource dependency tree, and they are not relevant to the content delivery optimization.
 
 **`initiatorUrl` is empty unless the resource is actually downloaded from network.**
 
@@ -57,7 +57,7 @@ There are a number of advantages to this approach.
 
 - It avoids overhead when the resources are loaded fast.
 
-- It simplifies implmenetation.
+- It simplifies implementation.
 
 ### 3. UA only partially implements the `initiator Info`.
 When the `initiator info` is missing for some resources, the partial resource dependency information is still useful. Therefore, a UA can release a particial `initiator info` implementation and make improvements later.

--- a/ResourceTimingInitiatorInfo/explainer.md
+++ b/ResourceTimingInitiatorInfo/explainer.md
@@ -43,15 +43,23 @@ Then we conclude that resource "apple" triggered the fetch of the resource "oran
 ## Missing `initiator info` values
 An empty `initiatorUrl` indicates the `initiator info` is missing. There are a number of possibilities discussed below.
 
-### `initiator` may not exist.
+### 1. `initiator` may not exist.
 A main page can be loaded according to the user navigation. For the main page, `initiator` doesn't exist.
 
-### Resources may be cached.
-Cached resources appear in `PerformanceResourceTiming` too. Such resources are not part of the resource dependency tree, and they are not relevant to the content delivery optimization.
+### 2. Resources may not be downloaded from network.
+Resources can be cached, or handled by services workers, instead of being downloaded from network.They still appear in `PerformanceResourceTiming`. Such resources are not part of the resource dependency tree, and they are not relevant to the content delivery optimization.
 
-It's easier if the `inititorUrl` is empty for cached resources: when constructing the dependency tree, only the `PerformanceResourceTiming` entries with valid `initiator info` are considered; and there is no need to filter out cached resources.
+**`initiatorUrl` is empty unless the resource is actually downloaded from network.**
 
-### UA only partially implements the `initiator Info`.
+There are a number of advantages to this approach.
+
+- It's easier to consume the output to construct the resource dependency tree: Only the `PerformanceResourceTiming` entries with valid `initiator info` are considered. No extra filter is needed.
+
+- It avoids overhead from the UA when the resources are loaded fast.
+
+- It simplifies implmenetation in the UA.
+
+### 3. UA only partially implements the `initiator Info`.
 When the `initiator info` is missing for some resources, the partial resource dependency information is still useful. Therefore, a UA can release a particial `initiator info` implementation and make improvements later.
 
 

--- a/ResourceTimingInitiatorInfo/explainer.md
+++ b/ResourceTimingInitiatorInfo/explainer.md
@@ -55,9 +55,9 @@ There are a number of advantages to this approach.
 
 - It's easier to consume the output to construct the resource dependency tree: Only the `PerformanceResourceTiming` entries with valid `initiator info` are considered. No extra filter is needed.
 
-- It avoids overhead from the UA when the resources are loaded fast.
+- It avoids overhead when the resources are loaded fast.
 
-- It simplifies implmenetation in the UA.
+- It simplifies implmenetation.
 
 ### 3. UA only partially implements the `initiator Info`.
 When the `initiator info` is missing for some resources, the partial resource dependency information is still useful. Therefore, a UA can release a particial `initiator info` implementation and make improvements later.


### PR DESCRIPTION
1. Should use the term "resources not downloaded" instead of "cached resources". (Resources can be handled by service workers)
2. List more advantages to leaving the `initiatorUrl` empty for resources that are not downloaded.