### PR TITLE
[AriaNotify] Update iframes details in explainer

### DIFF
--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -176,9 +176,10 @@ the user first.
 As iframes and other embedded content comes from external sources, web authors of the top-level context will not be
 permitted to add notifications within the embedded content. 
 
-On the other hand, the web authors of the iframe will be able to add notifications to their content. In order for these
-notifications to propagate to the top-level browsing context, we will require a new value to the `sandbox` attribute for
-`<iframe>` called `allow-aria-notify`.
+On the other hand, the web authors of the iframe will be able to add notifications to their content. We will create a new `Permissions-Policy` called `aria-notify`. 
+By default, `aria-notify` is allowed in iframes.  Authors can opt iframes out of aria-notify by:
+ - `<iframe allow="aria-notify 'none'">`
+ - `Permissions-Policy: aria-notify=(self)`
 
 ## Relationship to ARIA Live Regions
 There are some similarities between `ariaNotify` and the existing ARIA live regions. Some functionality provided by `ariaNotify` is not supported and cannot be mapped back directly to ARIA live regions. 

--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -542,3 +542,4 @@ available for content authors to validate the behavior of both ARIA live regions
  #2.7](https://www.w3.org/TR/security-privacy-questionnaire/#send-to-platform)) Should there be a practical limit on the
  amount of text that can be sent in one parameter to the API? Just like multiple-call DoS attacks, one call with an
  enormous amount of text could tie up an AT or cause a hang as data is marshalled across boundaries.
+ 

--- a/Accessibility/AriaNotify/explainer.md
+++ b/Accessibility/AriaNotify/explainer.md
@@ -542,4 +542,3 @@ available for content authors to validate the behavior of both ARIA live regions
  #2.7](https://www.w3.org/TR/security-privacy-questionnaire/#send-to-platform)) Should there be a practical limit on the
  amount of text that can be sent in one parameter to the API? Just like multiple-call DoS attacks, one call with an
  enormous amount of text could tie up an AT or cause a hang as data is marshalled across boundaries.
- 


### PR DESCRIPTION
This PR updates the "iframes and subresources" section of the AriaNotify explainer with the latest details.