### PR TITLE
[Gamepad] Fixed header sizing in explainer

### DIFF
--- a/GamepadEventDrivenInputAPI/explainer.md
+++ b/GamepadEventDrivenInputAPI/explainer.md
@@ -111,7 +111,7 @@ To address the challenges of input latency, this proposal introduces a new event
 
 These properties, `axesChanged`, `buttonsPressed`, `buttonsReleased`, and `buttonsValueChanged` properties are arrays of indices and follow the same indentification model as the [Gamepad.axes](https://w3c.github.io/gamepad/#dom-gamepad-axes) and [Gamepad.buttons](https://w3c.github.io/gamepad/#dom-gamepad-buttons) arrays.
 
-#### Event behavior
+### Event behavior
 Dispatched on the Gamepad Object: The rawgamepadinputchange event is dispatched on the Gamepad object that experienced the input change. This Gamepad instance is accessible via the event's [`target`](https://developer.mozilla.org/en-US/docs/Web/API/Event/target) property and represents a live object that reflects the current state of the device.
 
 Real-Time Updates: A new rawgamepadinputchange event is dispatched for every gamepad input state change, without delay or coalescing. This enables latency-sensitive applications, such as rhythm games, cloud gaming, or real-time multiplayer scenarios, to respond immediately and accurately to input.


### PR DESCRIPTION
"Event behavior" header size was not correct, fixed that. 