### PR TITLE
Update the NativeAuth API

### DIFF
--- a/PlatformAuthentication/explainer.md
+++ b/PlatformAuthentication/explainer.md
@@ -140,9 +140,9 @@ The GetTokenResult is a dictionary that contain either an error or the response 
 dictionary ErrorResult { 
     DOMString code, 
     DOMString? description, 
-    DOMString errorCode, 
+    DOMString? errorCode,
     DOMString? protocolError, 
-    DOMString status, 
+    DOMString? status,
     record<DOMString, DOMString>? properties 
 }   
 ```
@@ -278,6 +278,7 @@ The `SignOutResult` is also a dictionary that will contain an error in case ther
 
 ```
 dictionary SignOutResult  { 
+    boolean isSuccess,
     ErrorResult error 
 } 
 ```


### PR DESCRIPTION
Two changes in this PR:
1. Add the boolean value `isSuccess` to `SignOutResult` so that all the results are aligned and the user can always check `isSuccess` first to decide whether to display an error.

2. Mark `errorCode` and `status` in `ErrorResult` as optional as they are not always available.