### PR TITLE
Add note about ::tether to ::tooltip explainer

### DIFF
--- a/CSSTooltipPseudo/explainer.md
+++ b/CSSTooltipPseudo/explainer.md
@@ -872,7 +872,8 @@ psuedo.
 This addition would require allowing sub-psuedo elements within `::tooltip`.
 There would also need to be a way to know the position of the tooltip itself
 to position the arrow against, which can be accomplished with CSS Anchor
-Positioning.
+Positioning, along with the proposed [`::tether` pseudo element](
+https://github.com/w3c/csswg-drafts/issues/9271).
 
 ### Customizing `::tooltip` user interactions
 


### PR DESCRIPTION
We received [feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/1046) noting a proposal for a `::tether` pseudo element that we could use for the `::tooltip` arrow/pointer.

This change adds this as a note to the section on the future arrow/pointer idea as part of the tooltip proposal.