### PR TITLE
[ElementInternalsType] Introduce BehavesLike

### DIFF
--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -1,4 +1,4 @@
-# ElementInternals.type
+# Custom Elements with Native Element Behaviors
 
 ## Authors:
 - [Sanket Joshi](https://github.com/sanketj)
@@ -18,62 +18,93 @@ Web component authors often want to create custom elements that inherit the beha
 
 ### Goals
 - A solution for customized built-in elements that provides an improvement over `extends`/`is`, in terms of interoperability and functionality.
-- Supporting as many as customized built-in use cases as possible, though not necessarily all at once. Support for more `type` values can be added over time.
+- Supporting key customized built-in use cases, starting with button and label behaviors. Support for additional behaviors can be added over time.
 
 ### Non-goals
-- Deprecation of `extends`/`is`. This is something that can be considered independently, once `elementInternals.type` addresses developer needs sufficiently.
-- A declarative version of `elementInternals.type`. This requires finding a general solution for declarative custom elements with declarative `elementInternals`. This is a broader problem that should be explored separately.
+- Deprecation of `extends`/`is`.
+- A declarative version of this proposal. This requires finding a general solution for declarative custom elements. This is a broader problem that should be explored separately.
 
-## Proposal: add `type` property to `ElementInternals`
-The `ElementInternals` interface gives web developers a way to participate in HTML forms and integrate with the accessibility OM. This will be extended to support the creation of customized built-ins by adding a `type` property, which can be set to string values that represent native element types. The initial set of `type` values being proposed are listed below. Support for additional values may be added in the future.
-- `'' (empty string)` - this is the default value, indicating the custom element is not a customized built-in
-- `button` - for [button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-button) like behavior
-- `submit` - for [submit button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit) like behavior
-- `reset` - for [reset button](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-reset) like behavior
-- `label` - for [label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) like behavior
+## Proposal: add static `behavesLike` property with behavior-specific interface mixins
 
-If `elementInternals.type` is assigned any other value, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown.
-
-`elementInternals.type` should only be set once. If `elementInternals.type` has a non-empty string value and is attempted to be set again, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown. This works similar to how [`attachInternals` throws an error if called on an element more than once](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals:~:text=If%20this%27s%20attached%20internals%20is%20non%2Dnull%2C%20then%20throw%20an%20%22NotSupportedError%22%20DOMException).
-
-Setting `elementInternal.type` allows the custom element to support additional attributes. The full list for each type is provided in the sub-sections below. If any of the properties have been set prior to setting `elementInternals.type`, the attribute will be "reset" to the default state for that type. Below is an example showcasing this with the `disabled` attribute.
-
+Web component authors can now create custom elements with native behaviors by adding a static `behavesLike` property to their custom element class definition. This property can be set to string values that represent native element types:
 ```js
     class CustomButton extends HTMLElement {
-        static formAssociated = true;
-
-        constructor() {
-            super();
-            this.disabled = true;
-            this.internals_ = this.attachInternals();
-            this.internals_.type = 'button';
-            console.log(this.disabled);  // logs `false`
-        }
+        static behavesLike = 'button';
     }
     customElements.define('custom-button', CustomButton);
 ```
 
-### `elementInternals.type = 'button'`
-When `elementInternals.type = 'button'` is set in a custom element's constructor, the custom element will gain support for the attributes listed below.
-- [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
-- [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
-- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
-- [`popovertarget`](https://html.spec.whatwg.org/multipage/popover.html#attr-popovertarget)
-- [`popovertargetaction`](https://html.spec.whatwg.org/multipage/popover.html#attr-popovertargetaction)
-- [`command`](https://html.spec.whatwg.org/#attr-button-command)
-- [`commandfor`](https://html.spec.whatwg.org/#attr-button-commandfor)
-- [`interesttarget`](https://github.com/whatwg/html/pull/11006/files#:~:text=span%3E%20the%20%3Ccode%20data%2Dx%3D%22attr%2Dinteresttarget%22%3E-,interesttarget,-%3C/code%3E%20attribute.%3C/p%3E) - [currently experimental in Chromium](https://groups.google.com/a/chromium.org/g/blink-dev/c/LLgsMjTzmAY/m/5GUjSYC2AQAJ)
+Additionally, the proposal includes behavior-specific interface mixins that expose the full set of properties available to each element type. These mixins are available through `buttonMixin` and `labelMixin` properties on `ElementInternals`.
 
-Below is an example showcasing a custom button being used as a popup invoker. When the custom button is activated, ex. via a click, `div id="my-popover"` will be shown as a popover.
+The initial set of `behavesLike` values being proposed are listed below. Support for additional values may be added in the future.
+- `'button'` - for [button](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element) like behavior
+- `'label'` - for [label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) like behavior
+
+If `behavesLike` is assigned any other value, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown during `customElements.define()`.
+
+`behavesLike` is a static property that must be set during class definition and cannot be changed after the custom element is defined. This works similar to how [`formAssociated`](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example) is a static property that determines form association capabilities.
+
+### `static behavesLike = 'button'` and `elementInternals.buttonMixin`
+When `static behavesLike = 'button'` is set in a custom element's class definition, the custom element will gain support for all button-specific attributes and properties.
+
+**Supported attributes:**
+- `autofocus` - Automatically focus the form control when the page is loaded
+- `disabled` - Whether the form control is disabled
+- `form` - Associates the element with a form element
+- `formaction` - URL to use for form submission
+- `formenctype` - Entry list encoding type to use for form submission
+- `formmethod` - Variant to use for form submission
+- `formnovalidate` - Bypass form control validation for form submission
+- `formtarget` - Navigable for form submission
+- `name` - Name of the element to use for form submission
+- `type` - Type of button (submit/reset/button)
+- `value` - Value to be used for form submission
+- `popovertarget` - Targets a popover element to toggle, show, or hide
+- `popovertargetaction` - Indicates whether a targeted popover element is to be toggled, shown, or hidden
+- `command` - Indicates to the targeted element which action to take
+- `commandfor` - Targets another element to be invoked
+- `interesttarget` - [currently experimental in Chromium](https://groups.google.com/a/chromium.org/g/blink-dev/c/LLgsMjTzmAY/m/5GUjSYC2AQAJ)
+
+**Supported properties:**
+The `elementInternals.buttonMixin` property provides access to a `ButtonInternals` interface that exposes button-specific properties:
+- `disabled` - reflects the `disabled` attribute
+- `form` - returns the associated HTMLFormElement
+- `formAction` - reflects the `formaction` attribute  
+- `formEnctype` - reflects the `formenctype` attribute
+- `formMethod` - reflects the `formmethod` attribute
+- `formNoValidate` - reflects the `formnovalidate` attribute
+- `formTarget` - reflects the `formtarget` attribute
+- `labels` - returns a NodeList of associated label elements
+- `name` - reflects the `name` attribute
+- `type` - reflects the `type` attribute
+- `value` - reflects the `value` attribute
+- `willValidate` - indicates whether the element is a candidate for constraint validation
+- `validity` - returns the ValidityState representing validation states
+- `validationMessage` - returns localized validation message
+- `command` - returns the value of the `command` attribute
+- `commandForElement` - returns the Element referenced by the `commandfor` attribute  
+- `popoverTargetAction` - returns the value of the `popovertargetaction` attribute
+- `popoverTargetElement` - returns the Element referenced by the `popovertarget` attribute
+
+Below is an example showcasing a custom button being used as a popup invoker with access to both attributes and DOM properties:
 
 ```js
     class CustomButton extends HTMLElement {
-        static formAssociated = true;
+        static behavesLike = 'button';
 
         constructor() {
             super();
             this.internals_ = this.attachInternals();
-            this.internals_.type = 'button';
+        }
+
+        get popoverTargetElement() {
+            return this.internals_.buttonMixin?.popoverTargetElement ?? null;
+        }
+        
+        set popoverTargetElement(element) {
+            if (this.internals_.buttonMixin) {
+            this.internals_.buttonMixin.popoverTargetElement = element;
+            }
         }
     }
     customElements.define('custom-button', CustomButton);
@@ -83,73 +114,37 @@ Below is an example showcasing a custom button being used as a popup invoker. Wh
     <div id="my-popover" popover>This is popover content.</div>
 ```
 
-Like with native buttons, if the `disabled` attribute is set, a custom button cannot be activated and thus cannot invoke popovers.
+**Implicit button behavior:**
+Beyond attributes and properties, custom elements with `behavesLike = 'button'` also gain native button behaviors:
+- **Default submit behavior**: The default `type` is "submit", the button will submit its associated form when activated
+- **Implicit form submission**: When associated with a `<form>`, pressing Enter on an associated form control (eg, a text input) will trigger the custom button's submit behavior
+- **Form association**: The custom element automatically becomes form-associated and participates in form submission and validation
 
-### `elementInternals.type = 'submit'`
-Custom elements with `elementInternals.type = 'submit'` set will support the following attributes.
-- [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
-- [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
-- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
-- [`formAction`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formaction)
-- [`formEnctype`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formenctype)
-- [`formMethod`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formmethod)
-- [`formNoValidate`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formnovalidate)
-- [`formTarget`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formtarget)
-- [`name`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name)
-- [`value`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-value)
-- [`willValidate`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate)
-- [`validity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity)
-- [`validationMessage`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage)
-- [`checkValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity)
-- [`reportValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity)
-- [`setCustomValidity`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity)
-- [`name`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name)
-- [`value`](https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-value)
+### `static behavesLike = 'label'` and `elementInternals.labelMixin`
+When `static behavesLike = 'label'` is set in a custom element's class definition, the custom element will gain support for all label-specific attributes and properties.
 
-Below is an example showcasing a custom submit button being used to submit a form. When the custom button is activated, ex. via a click, the form will be submitted and the page will navigate.
+**Supported attributes:**
+- `for` - Associates the label with a form control via the referenced element's ID
 
-```js
-    class CustomSubmitButton extends HTMLElement {
-        static formAssociated = true;
+**Supported properties:**
+The `elementInternals.labelMixin` property provides access to a `LabelInternals` interface that exposes label-specific properties:
+- `htmlFor` - reflects the `for` attribute
+- `control` - returns the Element referenced by the `for` attribute (the labeled control)
+- `form` - returns the HTMLFormElement that the labeled control is associated with, or null if none
 
-        constructor() {
-            super();
-            this.internals_ = this.attachInternals();
-            this.internals_.type = 'submit';
-        }
-    }
-    customElements.define('custom-submit-button', CustomSubmitButton);
-```
-```html
-    <form action="http://www.bing.com">
-        <custom-submit-button>Submit</custom-submit-button>
-    </form>
-```
-
-If the `disabled` attribute is set on a custom submit button, it cannot be activated and thus cannot submit forms.
-
-### `elementInternals.type = 'reset'`
-Custom elements with `elementInternals.type = 'reset'` set will support the following attributes.
-- [`disabled`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled)
-- [`labels`](https://html.spec.whatwg.org/multipage/forms.html#dom-lfe-labels)
-- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
-
-### `elementInternals.type = 'label'`
-Custom elements with `elementInternals.type = 'label'` set will support the following attributes.
-- [`form`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form)
-- [`for`](https://html.spec.whatwg.org/multipage/forms.html#dom-label-htmlfor)
-- [`control`](https://html.spec.whatwg.org/multipage/forms.html#dom-label-control)
-
-Below is an example showcasing a custom label being used to label a checkbox. When the custom label is activated, ex. via a click, the checkbox is also activated, resulting in its state changing to checked.
+Below is an example showcasing a custom label being used to label a checkbox with access to both attributes and DOM properties:
 
 ```js
     class CustomLabel extends HTMLElement {
-        static formAssociated = true;
+        static behavesLike = 'label';
 
         constructor() {
             super();
             this.internals_ = this.attachInternals();
-            this.internals_.type = 'label';
+        }
+
+        get control() {
+            return this.internals.labelMixin?.control ?? null;
         }
     }
     customElements.define('custom-label', CustomLabel);
@@ -158,26 +153,94 @@ Below is an example showcasing a custom label being used to label a checkbox. Wh
    <custom-label for='my-checkbox'>Toggle checkbox</custom-label>
    <input type='checkbox' id='my-checkbox' />
 ```
+**Implicit label behavior:**
+Beyond attributes and properties, custom elements with `behavesLike = 'label'` also gain native label behaviors:
+- **Implicit association**: If no `for` attribute is specified, the first labelable element descendant automatically becomes the labeled control
+- **Click delegation**: Clicking the custom label will activate its associated control (focus text inputs, toggle checkboxes, etc.)
 
-### Order of precedence for used values: Element properties > `ElementInternals` properties > default properties via `elementInternals.type`
-When `elementInternals.type` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `elementInternals.type = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternals.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
 
-### `elementInternals.type` does not conflict with `extends`
-Per spec, [`attachInternals`](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals) cannot be called on custom elements that are defined with `extends`. Therefore, it is not possible to create a custom element that is defined with `extends` and also sets `elementInternals.type`.
+### Behavior-specific interfaces
 
-### `elementInternals.type` does not change element appearance
-Setting `elementInternals.type` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles from the native element.
+The proposal includes behavior-specific interfaces (`buttonMixin`, `labelMixin`) that provide access to DOM properties corresponding to element-specific attributes.
 
-### Customized built-ins must be [form-associated](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) to participate in forms
-Today, custom elements need to be defined as [form-associated](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-form-associated) to participate in forms. This is done by including `static formAssociated = true;` in its definition. Customized built-ins created by setting `elementInternals.type` will also need to be defined with `static formAssociated = true;` to participate in forms.
+**Interface availability:**
+- `elementInternals.buttonMixin` returns a `ButtonInternals` interface when `behavesLike` is `'button'`, otherwise `null`
+- `elementInternals.labelMixin` returns a `LabelInternals` interface when `behavesLike` is `'label'`, otherwise `null`
+
+**Benefits of the interface mixin approach:**
+- **Complete API surface**: Provides both attribute and property access, matching native elements
+- **Discoverability**: Grouped interfaces make it clear which properties are available for each behavior
+- **No naming conflicts**: Avoids conflicts when different element types have properties with the same name.
+
+**IDL definitions:**
+```webidl
+partial interface ElementInternals {
+  readonly attribute ButtonInternals? buttonMixin;
+  readonly attribute LabelInternals? labelMixin;
+};
+
+interface ButtonInternals {
+  attribute Element? popoverTargetElement;
+  attribute Element? commandForElement; 
+  attribute DOMString popoverTargetAction;
+  // ... additional properties skipped for brevity
+};
+
+interface LabelInternals {
+  attribute DOMString htmlFor;
+  readonly attribute Element? control;
+  // ... additional properties skipped for brevity
+};
+```
+
+### Order of precedence for used values: Element attributes/properties > `ElementInternals` properties > default properties via `behavesLike`
+When `behavesLike` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `behavesLike = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternals.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
+
+### `behavesLike` with `extends`/`is` customized built-ins
+If a custom element is defined with both `static behavesLike` and  `extends`/`is`, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown during `customElements.define()`.
+
+This is because `behavesLike` functionality depends on `ElementInternals` (for its interface mixins, e.g., `elementInternals.buttonMixin`, `elementInternals.labelMixin`) which won't be available if the element is defined with `extends`/`is` (https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals)
+
+### `behavesLike` does not change element appearance
+Setting `behavesLike` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles from the native element.
+
+### `behavesLike` and `formAssociated`
+If the element type specified by `behavesLike` is already a [form-associated element](https://html.spec.whatwg.org/multipage/forms.html#form-associated-element) (such as `'button'`), then `static formAssociated = true;` becomes a no-op since the element will automatically gain form association capabilities from its specified behavior.
 
 ## Alternatives considered
+
+### `elementInternals.type` property approach
+
+An earlier version of this proposal used a `type` property on `ElementInternals` that could be set at runtime in the constructor. This approach had several characteristics:
+
+- `elementInternals.type` could be set to values like `'button'`, `'submit'`, `'reset'`, `'label'`
+- The property could only be set once and would throw if set again
+- Setting occurred in the constructor after calling `attachInternals()`
+
+```js
+// Earlier elementInternals.type approach
+class CustomButton extends HTMLElement {
+    constructor() {
+        super();
+        this.internals_ = this.attachInternals();
+        this.internals_.type = 'button'; // Runtime setting
+    }
+}
+```
+This approach had several design issues:
+
+**Semantic inconsistency:**
+- **Mixed abstraction levels**: Values like `'button'`, `'submit'`, `'reset'`, `'label'` mixed element types (button, label) with button subtypes (submit, reset), creating unclear semantics about what the property actually represented
+
+**Timing and mutability concerns:**
+- **When to set**: Unclear whether the property should be set in the constructor, `connectedCallback()`, or elsewhere
+- **Immutability enforcement**: Complex logic needed to prevent the property from being changed after initial setting
+
+### `extends` and `is` attribute approach
 
 A partial solution for this problem already exists today. Authors can specify the `extends` option when [defining a custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define). Authors can then use the `is` attribute to give a built-in element a custom name, thereby turning it into a customized built-in element.
 
 Both `extends` and `is` are supported in Firefox and Chromium-based browsers. However, this solution has limitations, such as not being able to attach shadow trees to (most) customized built-in elements. Citing these limitations, Safari doesn't plan to support customized built-ins in this way and have shared their objections here: https://github.com/WebKit/standards-positions/issues/97#issuecomment-1328880274. As such, `extends` and `is` are not on a path to full interoperability today.
-
-The `elementInternals.type` proposal addresses many of the limitations with `extends`/`is`, including allowing customized built-ins to support shadow DOM. The proposal also has support from the WHATWG and multiple browser vendors (including Safari) as noted by a WG resolution here: https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455.
 
 ## Stakeholder Feedback / Opposition
 
@@ -192,4 +255,8 @@ The `elementInternals.type` proposal addresses many of the limitations with `ext
 Many thanks for valuable feedback and advice from:
 
 - [Mason Freed](https://github.com/mfreed7)
+- [Justin Fagnani](https://github.com/justinfagnani)
+- [Keith Cirkel](https://github.com/keithamus)
+- [Steve Orvell](https://github.com/sorvell)
+- [Daniel Clark](https://github.com/dandclark)
 - [Open UI Community Group](https://www.w3.org/community/open-ui/)

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -210,7 +210,7 @@ If a custom element is defined with both `static behavesLike` and  `extends`/`is
 This is because `behavesLike` functionality depends on `ElementInternals` (for its interface mixins, e.g., `elementInternals.buttonMixin`, `elementInternals.labelMixin`) which won't be available if the element is defined with `extends`/`is` (https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals)
 
 ### `behavesLike` does not change element appearance
-Setting `behavesLike` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles from the native element.
+Setting `behavesLike` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles that target the native element, since the custom element has a different tag name (e.g., `<fancy-button>` instead of `<button>`).
 
 ### `behavesLike` and `formAssociated`
 If the element type specified by `behavesLike` is already a [form-associated element](https://html.spec.whatwg.org/multipage/forms.html#form-associated-element) (such as `'button'`), then `static formAssociated = true/false;` becomes a no-op since the element will automatically gain form association capabilities from its specified behavior.

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -3,6 +3,7 @@
 ## Authors:
 - [Sanket Joshi](https://github.com/sanketj)
 - [Alex Keng](https://github.com/alexkeng)
+- [Ana Sollano Kim](https://github.com/anaskim)
 - [Chris Holt](https://github.com/chrisdholt)
 
 ## Participate
@@ -65,7 +66,7 @@ When `static behavesLike = 'button'` is set in a custom element's class definiti
 - `popovertargetaction` - Indicates whether a targeted popover element is to be toggled, shown, or hidden
 - `command` - Indicates to the targeted element which action to take
 - `commandfor` - Targets another element to be invoked
-- `interesttarget` - [currently experimental in Chromium](https://groups.google.com/a/chromium.org/g/blink-dev/c/LLgsMjTzmAY/m/5GUjSYC2AQAJ)
+- `interesttarget` - [currently experimental in Chromium](https://chromestatus.com/feature/4530756656562176?gate=4768466822496256)
 
 **Supported properties:**
 The `elementInternals.buttonMixin` property provides access to a `ButtonInternals` interface that exposes button-specific properties:
@@ -119,8 +120,11 @@ Below is an example showcasing a custom button being used as a popup invoker wit
 **Implicit button behavior:**
 Beyond attributes and properties, custom elements with `behavesLike = 'button'` also gain native button behaviors:
 - **Default submit behavior**: The default `type` is "submit", the button will submit its associated form when activated
-- **Implicit form submission**: When associated with a `<form>`, pressing Enter on an associated form control (eg, a text input) will trigger the custom button's submit behavior
+- **Implicit form submission**: When associated with a `<form>`, pressing Enter on an associated form control (eg, a text input) will trigger the custom button's submit behavior if the button's `type` is "submit".
 - **Form association**: The custom element automatically becomes form-associated and participates in form submission and validation
+- **Click event activation**: Fire click events when activated via mouse click, Enter key, Space key, or other activation methods
+- **Focusable by default**: The element becomes focusable and participates in tab navigation without requiring `tabindex`
+- **Default ARIA semantics**: Have an [button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role) default ARIA role
 
 ### `static behavesLike = 'label'` and `elementInternals.labelMixin`
 When `static behavesLike = 'label'` is set in a custom element's class definition, the custom element will gain support for all label-specific attributes and properties.
@@ -159,6 +163,7 @@ Below is an example showcasing a custom label being used to label a checkbox wit
 Beyond attributes and properties, custom elements with `behavesLike = 'label'` also gain native label behaviors:
 - **Implicit association**: If no `for` attribute is specified, the first labelable element descendant automatically becomes the labeled control
 - **Click delegation**: Clicking the custom label will activate its associated control (focus text inputs, toggle checkboxes, etc.)
+- **Accessibility integration**: The label becomes the associated element's accessible name for screen readers and other assistive technologies
 
 
 ### Behavior-specific interfaces
@@ -208,7 +213,7 @@ This is because `behavesLike` functionality depends on `ElementInternals` (for i
 Setting `behavesLike` gives a custom element native element like behavior, but the custom element's appearance does not change. In other words, the custom element does not take on default, author-specified or user-specified styles from the native element.
 
 ### `behavesLike` and `formAssociated`
-If the element type specified by `behavesLike` is already a [form-associated element](https://html.spec.whatwg.org/multipage/forms.html#form-associated-element) (such as `'button'`), then `static formAssociated = true;` becomes a no-op since the element will automatically gain form association capabilities from its specified behavior.
+If the element type specified by `behavesLike` is already a [form-associated element](https://html.spec.whatwg.org/multipage/forms.html#form-associated-element) (such as `'button'`), then `static formAssociated = true/false;` becomes a no-op since the element will automatically gain form association capabilities from its specified behavior.
 
 ## Alternatives considered
 
@@ -237,7 +242,7 @@ This approach had several design issues:
 
 **Timing and mutability concerns:**
 - **When to set**: Unclear whether the property should be set in the constructor, `connectedCallback()`, or elsewhere
-- **Immutability enforcement**: Complex logic needed to prevent the property from being changed after initial setting
+- **Immutability enforcement**: Additional logic needed to prevent the property from being changed after initial setting
 
 ### `extends` and `is` attribute approach
 
@@ -253,6 +258,8 @@ Both `extends` and `is` are supported in Firefox and Chromium-based browsers. Ho
 
 [WHATWG resolution to accept `elementInternals.type = 'button'`](https://github.com/openui/open-ui/issues/1088#issuecomment-2372520455)
 
+[WHATWG resolution to accept using static property instead of `elementInternals.type`](https://github.com/whatwg/html/issues/11390#issuecomment-3190443053)
+
 ## References & acknowledgements
 
 Many thanks for valuable feedback and advice from:
@@ -262,4 +269,5 @@ Many thanks for valuable feedback and advice from:
 - [Keith Cirkel](https://github.com/keithamus)
 - [Steve Orvell](https://github.com/sorvell)
 - [Daniel Clark](https://github.com/dandclark)
+- [Leo Lee](https://github.com/leotlee)
 - [Open UI Community Group](https://www.w3.org/community/open-ui/)

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -26,7 +26,8 @@ Web component authors often want to create custom elements that inherit the beha
 
 ## Proposal: add static `behavesLike` property with behavior-specific interface mixins
 
-Web component authors can now create custom elements with native behaviors by adding a static `behavesLike` property to their custom element class definition. This property can be set to string values that represent native element types:
+We propose enabling web component authors to create custom elements with native behaviors by adding a static `behavesLike` property to their custom element class definition. This property can be set to string values that represent native element types:
+
 ```js
     class CustomButton extends HTMLElement {
         static behavesLike = 'button';
@@ -42,7 +43,8 @@ The initial set of `behavesLike` values being proposed are listed below. Support
 
 If `behavesLike` is assigned any other value, a ["NotSupportedError"](https://webidl.spec.whatwg.org/#notsupportederror) [DOMException](https://webidl.spec.whatwg.org/#dfn-DOMException) should be thrown during `customElements.define()`.
 
-`behavesLike` is a static property that must be set during class definition and cannot be changed after the custom element is defined. This works similar to how [`formAssociated`](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example) is a static property that determines form association capabilities.
+`behavesLike` is a static property that must be set in the class definition and cannot be changed after the custom element is defined. This works similarly to the static [`formAssociated`](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example) property that determines form association capabilities.
+
 
 ### `static behavesLike = 'button'` and `elementInternals.buttonMixin`
 When `static behavesLike = 'button'` is set in a custom element's class definition, the custom element will gain support for all button-specific attributes and properties.
@@ -103,7 +105,7 @@ Below is an example showcasing a custom button being used as a popup invoker wit
         
         set popoverTargetElement(element) {
             if (this.internals_.buttonMixin) {
-            this.internals_.buttonMixin.popoverTargetElement = element;
+                this.internals_.buttonMixin.popoverTargetElement = element;
             }
         }
     }
@@ -193,7 +195,8 @@ interface LabelInternals {
 };
 ```
 
-### Order of precedence for used values: Element attributes/properties > `ElementInternals` properties > default properties via `behavesLike`
+### Order of precedence for used values: Element content attributes > `ElementInternals` properties > default properties via `behavesLike`
+
 When `behavesLike` is set, the custom element will be assigned the same defaults as the corresponding native element. For example, if `behavesLike = 'button'` is set, the custom element's default ARIA role will become `button` and this will be the used role if no explicit role is specified by the author. If the author sets `elementInternals.role`, the value of `elementInternals.role` will be the used role, taking precedence over the default role. If the author sets the `role` attribute on the custom element, the value of the `role` attribute will be the used role, taking precedence over both `elementInternals.role` and the default role.
 
 ### `behavesLike` with `extends`/`is` customized built-ins


### PR DESCRIPTION
- introduce static property, `BehavesLike`
- move `ElementInternals.type` to Alternatives
- add missing attributes/properties support for button/label
- add implicit behaviors section
- add throw at `customElements.define()` when `BehavesLike` is assigned invalid values (to address Keith's concern) 

(the section for the mixin approach will be added later)