### PR TITLE
Update Open Issues Declarative CSS Modules Explainer

### DIFF
--- a/ShadowDOM/explainer.md
+++ b/ShadowDOM/explainer.md
@@ -770,8 +770,8 @@ The following table compares pros and cons of the various proposals:
 
 ## Open issues
 * What happens if a `<template shadowrootadoptedstylesheets="">` references a specifier that was imported as a non-inline CSS module whose fetch hasn’t completed yet?
-  Leading idea: Non-declarative imports don't apply for declarative shadow roots if their status is set to "pending". Alternatively, we could disallow any non-declartive imports on `<template shadowrootadoptedstylesheets="">`.
-
+  Leading idea: Disallow any non-declartive imports on `<template shadowrootadoptedstylesheets="">`. This seems the safest for backwards compatibility, and a developer is unlikely to do specify a declarative and non-declarative specifier on purpose. Alternatively, non-declarative imports don't apply for declarative shadow roots if their status is set to "pending".
+* Was it ever intentional that `<script type="importmap">` works inside a shadow root?
 
 ## References and acknowledgements
 Many thanks for valuable feedback and advice from other contributors:


### PR DESCRIPTION
One of the open issues the [TAG review](https://github.com/w3ctag/design-reviews/issues/1000#issuecomment-3162121691) brought up is regarding import maps:

> Was it ever intentional that <script type="importmap"> works inside a shadow root? It'd be good to check with that feature's designers (e.g. @domenic) to ensure that encouraging its use there won't break any assumptions or encourage any footguns.

This slipped though the cracks on the last spec update from TAG review feedback, so this PR adds it, nearly verbatim, to the Open Issues section. 

This also updates language of the other open issue regarding a pending fetch with the same module specifier to prefer to be safer and immediately fail, as we discussed earlier today.