### PR TITLE
EventPhases: Fix reference to "addEventListener"

### DIFF
--- a/EventPhases/explainer.md
+++ b/EventPhases/explainer.md
@@ -187,7 +187,7 @@ foo.addEventListener(
 Syntax of the scheduling integration is TBD (e.g., should there be explicit `scheduler.postForRead()` and `scheduler.postForWrite()` API instead?). We could also imagine the event carrying scheduling methods for brevity:
 
 ```js
-foo.when("click", 
+foo.addEventListener("click", 
   (evt) => {
     // ...
     evt.on("write", () => { /* ... */ });


### PR DESCRIPTION
The focus of this example appears to
be the `evt.on("write"` idea.

The reference to the unexplained "when"
method seams the same as addEventListener
in the previous example, so make it match
to avoid distracting from the example's focus.