### PR TITLE
[Button Activation Behaviors] Scope goals and add non-goal

### DIFF
--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -22,11 +22,12 @@ Currently, web developers face challenges when trying to implement these behavio
 This proposal addresses these challenges by introducing a standardized way for custom elements to opt into specific button activation behaviors through a simple static property declaration. By building on the established pattern of [form-associated custom elements](https://html.spec.whatwg.org/dev/custom-elements.html#form-associated-custom-elements), this approach provides a familiar developer experience while ensuring cross-browser compatibility and proper integration with platform features like the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API).
 
 ### Goals
-- A solution to support key button activation use cases, particularly command invocation and form submission
+- A solution to support key button activation use cases, particularly command invocation.
 
 ### Non-goals
 - Providing an alternative to the customized built-in solution (`extends` and `is`), i.e., enabling a custom element to do everything a native button does.
 - A declarative version of this proposal. This requires finding a general solution for declarative custom elements, which should be explored separately.
+- Providing guidance on how to indicate that new behavior has been added to an element, which is discussed (here)[https://github.com/WICG/webcomponents/issues/1029].
 
 ## Proposal: add static `buttonActivationBehaviors` property
 We propose enabling web component authors to create custom elements with button activation behaviors by adding a static `buttonActivationBehaviors` property to their custom element class definition.

--- a/ElementInternalsType/explainer.md
+++ b/ElementInternalsType/explainer.md
@@ -27,7 +27,7 @@ This proposal addresses these challenges by introducing a standardized way for c
 ### Non-goals
 - Providing an alternative to the customized built-in solution (`extends` and `is`), i.e., enabling a custom element to do everything a native button does.
 - A declarative version of this proposal. This requires finding a general solution for declarative custom elements, which should be explored separately.
-- Providing guidance on how to indicate that new behavior has been added to an element, which is discussed (here)[https://github.com/WICG/webcomponents/issues/1029].
+- Providing guidance on how to indicate that new behavior has been added to an element, which is discussed [here](https://github.com/WICG/webcomponents/issues/1029).
 
 ## Proposal: add static `buttonActivationBehaviors` property
 We propose enabling web component authors to create custom elements with button activation behaviors by adding a static `buttonActivationBehaviors` property to their custom element class definition.


### PR DESCRIPTION
- Modified the goals and non-goals section. Exclude form association, include non-goal (custom attributes).