### PR TITLE
[WebInstallAPI] Add OT update and link to explainer

### DIFF
--- a/WebInstall/explainer.md
+++ b/WebInstall/explainer.md
@@ -6,7 +6,6 @@ Authors: [Diego Gonzalez](https://github.com/diekus)
 >**Here for Origin Trials?** 
 The Web Install API is currently available as an [Origin Trial](https://developer.chrome.com/docs/web-platform/origin-trials/) in Chrome and Microsoft Edge versions 143-148. See [Origin Trial Instructions](https://github.com/MicrosoftEdge/Demos/blob/main/pwa-web-install-api/README.md) to learn more.
 
-
 The work on Web Install has been separated into two explainers: _current_ and _background_ document installations. The '[**current document**](./explainer-current-doc.md)' installation refers to installation of the curently loaded web application and is [being discussed](https://github.com/w3c/manifest/pull/1175) in the Web Applications WG. The '[**background document**](./explainer-background-doc.md)' installation refers to installation of web applications different from the current loaded navigable. Background document installations are being discussed and incubated in WICG.
 
 | Explainer | Expected Venue |
@@ -22,7 +21,6 @@ The **Web Install API provides a way to democratise and decentralise web applica
 The current way of acquiring a web app may involve search, navigation, proprietary protocols, proprietary app banners, and multiple other workarounds. This can be confusing for end users that must learn how to acquire apps in every different platform, with even different browsers handling the acquisition process differently.
 
 The web platform doesn't have a built-in way to facilitate app discovery and distribution, the Web Install API aims to fix this.
-
 
 ## FAQs
 


### PR DESCRIPTION
Update Web Install explainer to add a message at the top about Origin Trials and a link to the README for more instructions.