### PR TITLE
Address feedback on platform-provided mixins explainer (2)

### DIFF
--- a/PlatformProvidedMixins/explainer.md
+++ b/PlatformProvidedMixins/explainer.md
@@ -80,8 +80,8 @@ This proposal introduces a `mixins` option to `attachInternals()` and a `mixinLi
 // Attach a mixin during initialization.
 this._internals = this.attachInternals({ mixins: [HTMLSubmitButtonMixin] });
 
-// Inspect attached mixins (read-only, for state access).
-console.log(this._internals.mixins.htmlSubmitButton.formAction);
+// Access and modify mixin state.
+this._internals.mixins.htmlSubmitButton.formAction = '/custom';
 
 // Dynamically update the mixin list.
 this._internals.mixinList = [HTMLResetButtonMixin];

--- a/PlatformProvidedMixins/explainer.md
+++ b/PlatformProvidedMixins/explainer.md
@@ -317,11 +317,14 @@ customElements.define('ds-button', DesignSystemButton);
 ```
 
 The element gains:
-- **Platform event handling**: Click and keyboard activation (Space/Enter).
-- **Accessibility**: Implicit ARIA `role="button"` (overridable by the author).
-- **Form integration**: Form submission/reset on activation, `:default` pseudo-class matching, and implicit submission participation.
-- **Dynamic behavior**: The `type` attribute can be changed at runtime to switch between behaviors.
-- **State access**: Mixin properties like `disabled` and `formAction` are accessible and can be exposed.
+- Click and keyboard activation (Space/Enter).
+- Implicit ARIA `role="button"` that can be overriden by the web author.
+- Form submission on activation.
+- `:default` pseudo-class matching.
+- Participation in implicit form submission.
+- Ability to inspect its own properties via `this._internals.mixins`.
+- The `type` attribute can be changed at runtime to switch between behaviors.
+- Mixin properties like `disabled` and `formAction` are accessible and can be exposed.
 
 ## Future Work
 

--- a/PlatformProvidedMixins/explainer.md
+++ b/PlatformProvidedMixins/explainer.md
@@ -214,7 +214,7 @@ This proposal supports common web component patterns:
   </custom-button>
   ```
 
-### Use Case: Design System Button
+### Use case: Design system button
 
 While this proposal only introduces `HTMLSubmitButtonMixin`, the example below references `HTMLResetButtonMixin` and `HTMLButtonMixin` to illustrate how switching would work once additional mixins become available in the future.
 

--- a/PlatformProvidedMixins/explainer.md
+++ b/PlatformProvidedMixins/explainer.md
@@ -259,9 +259,10 @@ class DesignSystemButton extends HTMLElement {
         // Sync HTML attributes to mixin state.
         const submitMixin = this._internals.mixins.htmlSubmitButton;
         if (submitMixin) {
-            submitMixin.disabled = this.hasAttribute('disabled');
             submitMixin.formAction = this.getAttribute('formaction') || '';
         }
+        // Other attributes like `disabled`, `value`, etc. would be set on
+        // the proper mixin interface.
     }
 
     // Expose element state.


### PR DESCRIPTION
# Updates
- Added `mixinList` to main proposal.
- Dropped `Mixin` in `this.internals.mixins.htmlSubmitButton` calls to access state.
- Updated example of a design system button.
- Added two new subsections in "Future work" to mention user-defined mixins and mixins in native HTML elements.
- Minor nits.