### PR TITLE
Address feedback on platform-provided behaviors explainer (4)

### DIFF
--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -747,7 +747,9 @@ class TooltipBehavior extends PlatformBehavior {
   }
 
   #show = () => {
-    if (!this.#content) return;
+    if (!this.#content) {
+      return;
+    }
     this.#tooltipElement = document.createElement('div');
     this.#tooltipElement.className = 'tooltip';
     this.#tooltipElement.textContent = this.#content;
@@ -761,8 +763,12 @@ class TooltipBehavior extends PlatformBehavior {
     this.#tooltipElement = null;
   };
 
-  get content() { return this.#content; }
-  set content(val) { this.#content = val; }
+  get content() {
+    return this.#content;
+  }
+  set content(val) {
+    this.#content = val;
+  }
 }
 // Registration
 PlatformBehavior.define('tooltip', TooltipBehavior);
@@ -825,8 +831,12 @@ class HTMLDialogBehaviorPolyfill extends PlatformBehavior {
   }
 
   close(returnValue) {
-    if (!this.#open) return;
-    if (returnValue !== undefined) this.#returnValue = returnValue;
+    if (!this.#open) {
+      return;
+    }
+    if (returnValue !== undefined) {
+      this.#returnValue = returnValue;
+    }
     this.#open = false;
     this.element.removeAttribute('open');
     this.#previouslyFocused?.focus();
@@ -837,15 +847,23 @@ class HTMLDialogBehaviorPolyfill extends PlatformBehavior {
     if (e.key === 'Escape' && this.#open) {
       const cancelEvent = new Event('cancel', { cancelable: true });
       this.element.dispatchEvent(cancelEvent);
-      if (!cancelEvent.defaultPrevented) this.close();
+      if (!cancelEvent.defaultPrevented) {
+        this.close();
+      }
     }
   };
 
   // Implementation of focus trapping, backdrop click handling, etc.
 
-  get open() { return this.#open; }
-  get returnValue() { return this.#returnValue; }
-  set returnValue(val) { this.#returnValue = val; }
+  get open() {
+    return this.#open;
+  }
+  get returnValue() {
+    return this.#returnValue;
+  }
+  set returnValue(val) {
+    this.#returnValue = val;
+  }
 }
 PlatformBehavior.define('dialog', HTMLDialogBehaviorPolyfill);
 

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -240,7 +240,7 @@ Mutate the array directly:
 this._internals.behaviors[0] = HTMLButtonBehavior;
 ```
 
-To access a behavior state, iteration or find() is required:
+To access a behavior state, iteration or `find()` is required:
 ```javascript
 for (const behavior of this._internals.behaviors) {
   if (behavior instanceof HTMLSubmitButtonBehavior) {

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -856,15 +856,13 @@ const HTMLDialogBehavior =
 
 Although the polyfill above can't fully replicate a native `<dialog>` element (no true top layer, no `::backdrop`, no `:modal`), it provides a reasonable approximation.
 
-#### Considerations for User-Defined Behaviors
+#### Considerations for user-defined behaviors
 
-- **Lifecycle hooks**: `onAttached(internals)`, `onDetached()`, `onAttributeChanged(name, oldVal, newVal)`
-- **Base class**: `Behavior` provides utilities like `setDefaultRole()`, `setFocusable()`, `invalidatePseudoClass()`, and access to `this.element`
-- **Conflict resolution**: User-defined behaviors follow the same order-based resolution as platform behaviors
-- **Interop**: User behaviors can compose with platform behaviors
-- **Registration**: `Behavior.define(name, BehaviorClass)` registers for named access via `internals.behaviors.<name>`
-
-The initial ship does not need to include user-defined behaviors, but the design should accommodate them. This ensures the API shape is correct and developers can reason about platform behaviors as "behaviors they could have written."
+- Lifecycle hooks: `onAttached(internals)`, `onDetached()`, `onAttributeChanged(name, oldVal, newVal)`
+- `PlatformBehavior` would need to provide utilities like `setDefaultRole()`, `setFocusable()`, `invalidatePseudoClass()`, and access to `this.element`.
+- User behaviors can compose with platform-provided behaviors
+- The same conflict resolution strategies that apply to platform behaviors would need to work with user-defined behaviors.
+- How would custom behaviors be defined and registered? `Behavior.define(name, BehaviorClass)` registers for named access via `internals.behaviors.<name>`?
 
 ### Behaviors in Native HTML Elements
 


### PR DESCRIPTION
# Updates
- Added section to clarify addition of duplicate behaviors.
- Added section to discuss API naming, also added a couple of alternatives to consider.
- Added section on composition and conflict resolution (deleted it from Future work and brought it up to the main proposal to explore this further).
- Added examples of compatible and conflicting behaviors, issues and resolution.
- Expanded the section of developer-defined behaviors:
  - Example of a developer-defined behavior
  - Example of pollyfill
  - Expanded considerations
- Some nits and added links to further clarify user research.
