### PR TITLE
Add open questions to Network Efficiency Guardrails explainer

### DIFF
--- a/PerformanceControlOfEmbeddedContent/neg-explainer.md
+++ b/PerformanceControlOfEmbeddedContent/neg-explainer.md
@@ -249,3 +249,4 @@ And to the contributors and reviewers who helped shape the `network-efficiency-g
 
 * [Yoav Weiss](https://github.com/yoavweiss)
 * [Fabio Rocha](https://github.com/fabiorocha)
+* [Adam Rice](https://github.com/ricea)


### PR DESCRIPTION
Transfer new comments from [design doc](https://docs.google.com/document/d/1RGxvtkoQbvApLVdipiASoUQjC0Jf-IKD9qV1EfUJHAQ) as open questions in Network Efficiency Guardrails explainer.