### PR TITLE
Platform provided behaviors feedback 6

### DIFF
--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -170,7 +170,7 @@ class CustomSubmitButton extends HTMLElement {
 
 To expose properties like `disabled` or `formAction` to external code, authors define getters and setters that delegate to the behavior. This gives authors full control over their element's public API.
 
-Authors are also responsible for attribute reflection. If the author wants HTML attributes on their custom element (e.g., `<my-button formaction="/save">`) to affect the behavior, they need to observe and forward those attributes using the standard `attributeChangedCallback`:
+Authors are also responsible for attribute reflection. If the author wants HTML attributes on their custom element (e.g., `<my-button formaction="/save">`) to affect the behavior, they need to observe and forward those attributes using `attributeChangedCallback`:
 
 ```javascript
 class CustomButton extends HTMLElement {
@@ -648,10 +648,10 @@ The element gains:
 
 Consider `behaviors: [submitBehavior, resetBehavior, buttonBehavior]` with the intent to toggle behaviors:
 
-- Under last-in-wins, only `buttonBehavior`'s property values (the last in the array) determine the element's effective state. For `disabled`, this means setting `submitBehavior.disabled` or `resetBehavior.disabled` has no effect — only `buttonBehavior.disabled` controls whether the element matches `:disabled`, is removed from the tab order, and stops receiving activation events (no click or keyboard handler from any behavior runs while disabled).
+- Under last-in-wins, only `buttonBehavior`'s property values (the last in the array) determine the element's effective state. For `disabled`, this means setting `submitBehavior.disabled` or `resetBehavior.disabled` has no effect as only `buttonBehavior.disabled` controls whether the element matches `:disabled`, is removed from the tab order, and stops receiving activation events (no click or keyboard handler from any behavior runs while disabled).
 - All three behaviors register click handlers with different effects. Under strict last-in-wins (Option A), only `buttonBehavior`'s handler runs. Under additive events (Option B), all handlers run (the element would submit and reset the form on every click).
 
-Because `disabled` cannot selectively silence individual behaviors and conflict resolution applies uniformly to all attached behaviors, loading all three simultaneously and switching between them is not viable. Determining the behavior once at connection time is the recommended pattern.
+Because `disabled` cannot selectively silence individual behaviors and conflict resolution applies uniformly to all attached behaviors, loading all three simultaneously and switching between them is not viable.
 
 ### Framework use cases
 
@@ -874,7 +874,7 @@ class CustomButton extends HTMLElement {
 
 #### PlatformBehavior API
 
-For developer-defined behaviors to work, `PlatformBehavior` would need to expose an API that lets web developers set accessibility defaults, receive lifecycle notifications, and reference the host element. The table below describes what the base class would need to provide for developer-defined subclasses:
+For developer-defined behaviors to work, `PlatformBehavior` would need to expose an API that lets web developers set accessibility defaults, receive lifecycle notifications, and reference the host element:
 
 | Member | Kind | Description |
 |--------|------|-------------|
@@ -883,7 +883,7 @@ For developer-defined behaviors to work, `PlatformBehavior` would need to expose
 | `setDefaultTabIndex(index)` | Method | Sets the element's implicit tab index, making it focusable without an explicit `tabindex` attribute. |
 | `behaviorAttachedCallback(internals)` | Lifecycle | Called when the behavior is attached to an element via `attachInternals()`. Receives the `ElementInternals` object. |
 
-The following example shows how `HTMLButtonBehavior` (the plain `type="button"` behavior) would be implemented in userland:
+The following example shows how `HTMLButtonBehavior` (`type="button"`) would be implemented in userland:
 
 ```javascript
 class HTMLButtonBehaviorExample extends PlatformBehavior {

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -168,7 +168,24 @@ class CustomSubmitButton extends HTMLElement {
 }
 ```
 
-To expose properties like `disabled` or `formAction` to external code, authors define getters and setters that delegate to the behavior. Authors are also responsible for attribute reflection (observing HTML attributes and mapping them to the corresponding properties). This gives authors full control over their element's public API.
+To expose properties like `disabled` or `formAction` to external code, authors define getters and setters that delegate to the behavior. This gives authors full control over their element's public API.
+
+Authors are also responsible for attribute reflection. If the author wants HTML attributes on their custom element (e.g., `<my-button formaction="/save">`) to affect the behavior, they need to observe and forward those attributes using the standard `attributeChangedCallback`:
+
+```javascript
+class CustomButton extends HTMLElement {
+    static observedAttributes = ['disabled', 'formaction'];
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (name === 'disabled') {
+            this._submitBehavior.disabled = newValue !== null;
+        } else if (name === 'formaction') {
+            this._submitBehavior.formAction = newValue ?? '';
+        }
+    }
+}
+```
+*Note: platform-provided behaviors handle their internal attribute observation. For example, when the platform triggers form submission, `HTMLSubmitButtonBehavior` uses the current `formAction` value without any author intervention. The forwarding step above is only needed to connect HTML attributes on the custom element to the behavior's properties.*
 
 ### Behavior lifecycle
 
@@ -239,7 +256,6 @@ class TooltipBehavior {
   #content = '';
 
   behaviorAttachedCallback(internals) { /* ... */ }
-  behaviorDetachedCallback() { /* ... */ }
 
   get content() { return this.#content; }
   set content(val) { this.#content = val; }
@@ -527,8 +543,6 @@ This proposal supports common web component patterns:
 
 While this proposal only introduces `HTMLSubmitButtonBehavior`, the example below references `HTMLResetButtonBehavior` and `HTMLButtonBehavior` to illustrate how switching would work once additional behaviors become available in the future.
 
-#### Approach A: Single behavior, determined at connection time
-
 A design system can use delayed `attachInternals()` to determine the behavior based on the initial `type` attribute. This approach uses a single class while keeping behaviors immutable after attachment.
 
 ```javascript
@@ -618,94 +632,21 @@ class DesignSystemButton extends HTMLElement {
 customElements.define('ds-button', DesignSystemButton);
 ```
 
-*Note: Changing the `type` attribute after the element connects has no effect on behavior. The behavior is determined once at first connection time. This is a deliberate trade-off: it simplifies the mental model at the cost of diverging from native `<button>`, where `type=` can change at any time.*
+*Note: Changing the `type` attribute after the element connects has no effect on behavior, as the behavior is determined once at first connection time.*
 
-#### Approach B: All behaviors loaded, activation determined by type
+#### Why not load all three behaviors?
 
-An alternative approach loads all three button behaviors at once and uses a `type` property to control which one is active. This mirrors native `<button>` more closely since `type=` can change at any time:
+An alternative approach — loading all three button behaviors at once and toggling which one is "active" via the `disabled` property — initially seems appealing because it would allow `type=` to change at any time, matching native `<button>`. However, this approach has fundamental problems due to how `disabled` and conflict resolution interact.
 
-```javascript
-class DesignSystemButton extends HTMLElement {
-    static formAssociated = true;
-    static observedAttributes = ['type', 'disabled', 'formaction'];
+Consider `behaviors: [submitBehavior, resetBehavior, buttonBehavior]` with the intent to "disable" non-active behaviors:
 
-    #submitBehavior = new HTMLSubmitButtonBehavior();
-    #resetBehavior = new HTMLResetButtonBehavior();
-    #buttonBehavior = new HTMLButtonBehavior();
-    #internals = null;
-    #type = 'button';
+**`disabled` is user-facing, not behavior-scoping.** Setting `behavior.disabled = true` makes the *element* disabled — greyed out, removed from tab order, unable to accept clicks. It doesn't mean "this behavior is inactive while others remain active." There is no per-behavior activation toggle; `disabled` is a property of the element's interaction state. Under last-in-wins, `buttonBehavior.disabled` (the last in the array) determines whether the element is disabled, regardless of what the other behaviors' `disabled` values are set to.
 
-    constructor() {
-        super();
-        this.attachShadow({ mode: "open" });
-        this.#internals = this.attachInternals({
-            behaviors: [this.#submitBehavior, this.#resetBehavior, this.#buttonBehavior]
-        });
-    }
+**Property collisions under last-in-wins.** Properties like `name` and `value` are provided by all three behaviors, so the last behavior's values win. This means `submitBehavior.name` and `submitBehavior.value` — the ones that should participate in form data — are shadowed by `buttonBehavior.name` and `buttonBehavior.value`.
 
-    connectedCallback() {
-        this.#type = this.getAttribute('type') || 'button';
-        this.#syncDisabledState();
-        this.#render();
-    }
+**Event handler collisions.** All three behaviors register click handlers with different effects (submit form, reset form, do nothing). Under strict last-in-wins (Option A), only `buttonBehavior`'s handler runs — the element can never submit or reset. Under additive events (Option B), all handlers run simultaneously — the element would submit *and* reset the form on every click. Under the event-handled flag (Alternative 3), the first behavior to handle the click wins, making it impossible to switch the effective behavior without reordering the array.
 
-    attributeChangedCallback(name, oldValue, newValue) {
-        switch (name) {
-            case 'type':
-                this.#type = newValue || 'button';
-                this.#syncDisabledState();
-                this.#render();
-                break;
-            case 'disabled':
-                this.#syncDisabledState();
-                break;
-            case 'formaction':
-                this.#submitBehavior.formAction = newValue ?? '';
-                break;
-        }
-    }
-
-    #syncDisabledState() {
-        const isDisabled = this.hasAttribute('disabled');
-        // Disable all non-active behaviors so they don't respond to activation.
-        this.#submitBehavior.disabled = isDisabled || this.#type !== 'submit';
-        this.#resetBehavior.disabled = isDisabled || this.#type !== 'reset';
-        this.#buttonBehavior.disabled = isDisabled || this.#type !== 'button';
-    }
-
-    get type() { return this.#type; }
-    set type(val) { this.setAttribute('type', val); }
-
-    get disabled() { return this.hasAttribute('disabled'); }
-    set disabled(val) { this.toggleAttribute('disabled', val); }
-
-    #render() {
-        const isSubmit = this.#type === 'submit';
-        const isReset = this.#type === 'reset';
-
-        this.shadowRoot.innerHTML = `
-            <style>
-                :host { display: inline-block; padding: 8px 16px; cursor: pointer; }
-                :host(:disabled) { opacity: 0.5; cursor: not-allowed; }
-            </style>
-            ${isSubmit ? '💾' : isReset ? '🔄' : ''} <slot></slot>
-        `;
-    }
-}
-customElements.define('ds-button', DesignSystemButton);
-```
-
-This approach uses `disabled` on non-active behaviors to prevent them from responding to events. Changing `type=` at any time switches which behavior is active, matching native `<button>` semantics.
-
-**Trade-offs:**
-
-| | Approach A (single behavior) | Approach B (all behaviors) |
-|--|--|--|
-| `type=` changes | Ignored after connection | Supported at any time |
-| Memory | One behavior instance | Three behavior instances |
-| Complexity | Simpler | Must manage disabled state across behaviors |
-| Native `<button>` parity | Diverges (type is fixed) | Closer match |
-| Conflict resolution | Not needed (single behavior) | Needs care: all behaviors attached, only one active |
+Because `disabled` cannot selectively silence individual behaviors and conflict resolution applies uniformly to all attached behaviors, loading all three simultaneously and switching between them is not viable. Determining the behavior once at connection time — as shown above — is the recommended pattern.
 
 ```html
 <form action="/save" method="post">
@@ -899,8 +840,6 @@ The `PlatformBehavior` base class provides the following capabilities to both pl
 | `setDefaultRole(role)` | Method | Sets the element's implicit ARIA role (reflected by `ElementInternals.role`). Multiple behaviors can call this; conflict resolution determines which role wins. |
 | `setDefaultTabIndex(index)` | Method | Sets the element's implicit tab index, making it focusable without an explicit `tabindex` attribute. |
 | `behaviorAttachedCallback(internals)` | Lifecycle | Called when the behavior is attached to an element via `attachInternals()`. Receives the `ElementInternals` object. |
-| `behaviorDetachedCallback()` | Lifecycle | Called when the behavior is detached or the element is disconnected. |
-| `behaviorAttributeChangedCallback(name, oldValue, newValue)` | Lifecycle | *(Under consideration)* Called when an observed attribute changes. See [Attribute change monitoring](#attribute-change-monitoring). |
 | `disabled` | Property | Gets/sets whether the behavior is disabled. When `true`, the behavior does not respond to activation events and the element matches `:disabled`. |
 
 > **Note:** The exact surface of `PlatformBehavior` is still being refined. The table above represents the current thinking and is subject to change based on feedback and implementation experience.
@@ -928,13 +867,6 @@ class HTMLButtonBehaviorSketch extends PlatformBehavior {
     this.element.addEventListener('click', this.#handleClick);
     this.element.addEventListener('keydown', this.#handleKeydown);
     this.element.addEventListener('keyup', this.#handleKeyup);
-  }
-
-  behaviorDetachedCallback() {
-    this.element.removeEventListener('click', this.#handleClick);
-    this.element.removeEventListener('keydown', this.#handleKeydown);
-    this.element.removeEventListener('keyup', this.#handleKeyup);
-    this.#internals = null;
   }
 
   // Activation behavior: for type="button" there is no default action,
@@ -1001,14 +933,6 @@ class TooltipBehavior extends PlatformBehavior {
     this.element.addEventListener('blur', this.#hide);
   }
 
-  behaviorDetachedCallback() {
-    this.element.removeEventListener('mouseenter', this.#show);
-    this.element.removeEventListener('mouseleave', this.#hide);
-    this.element.removeEventListener('focus', this.#show);
-    this.element.removeEventListener('blur', this.#hide);
-    this.#hide();
-  }
-
   #show = () => {
     if (!this.#content) {
       return;
@@ -1035,7 +959,7 @@ class TooltipBehavior extends PlatformBehavior {
 }
 ```
 
-Behaviors are classes with the appropriate methods (`behaviorAttachedCallback`, `behaviorDetachedCallback`). The behavior is instantiated and passed to `behaviors`:
+Behaviors are classes with a `behaviorAttachedCallback` method. The behavior is instantiated and passed to `behaviors`:
 
 ```javascript
 class CustomButton extends HTMLElement {
@@ -1074,12 +998,6 @@ class HTMLDialogBehaviorPolyfill extends PlatformBehavior {
     this.setDefaultRole('dialog');
     this.element.addEventListener('keydown', this.#handleKeydown);
     this.element.addEventListener('click', this.#handleBackdropClick);
-  }
-
-  behaviorDetachedCallback() {
-    this.element.removeEventListener('keydown', this.#handleKeydown);
-    this.element.removeEventListener('click', this.#handleBackdropClick);
-    this.close();
   }
 
   show() {
@@ -1256,130 +1174,22 @@ For behaviors, the same problems would apply: if behaviors could be swapped dyna
 
 If compelling use cases emerge that genuinely require dynamic behavior composition, the API could be extended to use `ObservableArray` with lifecycle callbacks. This would be a backwards-compatible change (making the array mutable doesn't break code that treats it as read-only). However, we believe static behaviors will cover the vast majority of real-world needs.
 
-### Attribute change monitoring
+### Is there a better name than "behavior" for this concept?
 
-<a id="attribute-change-monitoring"></a>
+The word "behavior" has some drawbacks:
 
-Behaviors often need to respond to attribute changes on their host element. For example, a submit button behavior needs to react when `formaction` changes; a checkbox behavior needs to react when `checked` changes. Currently, this requires one of two approaches, each with drawbacks:
+- "behaviour" vs "behavior" may cause some friction for contributors.
+- Shorter names would improve ergonomics.
+- "Behavior" is used in other contexts (such as CSS scroll-behavior), which could cause confusion.
 
-#### Current approach: Manual forwarding from `attributeChangedCallback`
-
-The custom element author explicitly forwards attribute changes to the behavior:
-
-```javascript
-class DesignSystemButton extends HTMLElement {
-    static observedAttributes = ['disabled', 'formaction'];
-
-    attributeChangedCallback(name, oldValue, newValue) {
-        if (name === 'disabled') {
-            this._submitBehavior.disabled = newValue !== null;
-        } else if (name === 'formaction') {
-            this._submitBehavior.formAction = newValue ?? '';
-        }
-    }
-}
-```
-
-**Pros:**
-- Authors have full control over which attributes map to which behavior properties.
-- No new API needed.
-
-**Cons:**
-- Boilerplate: Every attribute the behavior cares about must be manually forwarded.
-- Error-prone: Authors can forget to forward an attribute, leading to subtle bugs.
-- Coupling: The custom element must know which attributes each behavior needs.
-
-#### Alternative: MutationObserver inside the behavior
-
-A behavior could observe its own element's attributes:
-
-```javascript
-class SubmitBehavior extends PlatformBehavior {
-    #observer = null;
-
-    behaviorAttachedCallback(internals) {
-        this.#observer = new MutationObserver(mutations => {
-            for (const m of mutations) {
-                if (m.attributeName === 'formaction') {
-                    this.formAction = this.element.getAttribute('formaction') ?? '';
-                }
-            }
-        });
-        this.#observer.observe(this.element, { attributes: true });
-    }
-
-    behaviorDetachedCallback() {
-        this.#observer?.disconnect();
-    }
-}
-```
-
-**Pros:**
-- The behavior is self-contained—no manual forwarding needed.
-
-**Cons:**
-- `MutationObserver` is asynchronous (microtask-based), which means attribute changes are not observed synchronously. This can cause flickering or missed intermediate states.
-- Performance overhead: creating an observer per behavior per element is wasteful.
-- Ergonomic mismatch: `MutationObserver` was designed for DOM observation, not for component-internal attribute routing.
-
-#### Potential solution: `behaviorAttributeChangedCallback`
-
-A dedicated callback, analogous to the custom element's `attributeChangedCallback`, could allow behaviors to declare which attributes they observe:
-
-```javascript
-class SubmitBehaviorSketch extends PlatformBehavior {
-    static observedAttributes = ['formaction', 'formmethod', 'formenctype',
-                                 'formnovalidate', 'formtarget', 'disabled'];
-
-    behaviorAttributeChangedCallback(name, oldValue, newValue) {
-        switch (name) {
-            case 'disabled':
-                this.disabled = newValue !== null;
-                break;
-            case 'formaction':
-                this.formAction = newValue ?? '';
-                break;
-            // ... other attribute mappings.
-        }
-    }
-}
-```
-
-**Pros:**
-- Synchronous, like `attributeChangedCallback`.
-- Behaviors are self-contained: they declare what they need and react to it.
-- No MutationObserver overhead.
-- Mirrors the familiar `observedAttributes` / `attributeChangedCallback` pattern.
-
-**Cons:**
-- New lifecycle callback to implement and specify.
-- Potential ordering question: does the element's `attributeChangedCallback` fire before or after the behavior's `behaviorAttributeChangedCallback`?
-- If both the element and the behavior respond to the same attribute, there may be redundant processing.
-
-> **Open question:** Should `behaviorAttributeChangedCallback` be part of the initial proposal, or deferred to a later iteration? Platform-provided behaviors like `HTMLSubmitButtonBehavior` already embed their attribute observation in native code, so this callback is primarily needed for developer-defined behaviors and polyfills.
-
-### Naming: "behavior" vs alternatives
-
-The word "behavior" has been used throughout this proposal, but it has some drawbacks:
-
-- **Spelling:** "behaviour" (British) vs "behavior" (American) is a common source of confusion in codebases with international contributors. APIs with regional spelling variants (e.g., `colour` vs `color` in CSS) are a known pain point.
-- **Length:** `HTMLSubmitButtonBehavior` is 25 characters. Shorter names would improve ergonomics, especially given how frequently these names appear in code.
-- **Overloaded:** "Behavior" is used in many other contexts (CSS scroll-behavior, HTC behaviors in legacy IE, BehaviorSubject in RxJS), which could cause confusion.
-
-Alternative names under consideration:
+Alternatives:
 
 | Name | Example class | Example API | Notes |
 |------|--------------|-------------|-------|
-| **behavior** (current) | `HTMLSubmitButtonBehavior` | `attachInternals({ behaviors: [...] })` | Clear meaning; spelling/length concerns |
-| **trait** | `HTMLSubmitButtonTrait` | `attachInternals({ traits: [...] })` | Short; Rust/Scala precedent for composable units; may confuse Rust developers (traits are interfaces, not instances in Rust) |
-| **facet** | `HTMLSubmitButtonFacet` | `attachInternals({ facets: [...] })` | Short; implies "one aspect of a larger whole"; less common in programming |
-| **mixin** | `HTMLSubmitButtonMixin` | `attachInternals({ mixins: [...] })` | Familiar concept; but "mixin" implies class-level composition (inheritance), not instance-level |
-| **cap** (capability) | `HTMLSubmitButtonCap` | `attachInternals({ caps: [...] })` | Very short; "capability" is well-understood; but "cap" is ambiguous on its own |
-| **feature** | `HTMLSubmitButtonFeature` | `attachInternals({ features: [...] })` | Intuitive; but "feature" is very generic and overloaded in web specs (Feature Policy, `@supports`) |
-| **aspect** | `HTMLSubmitButtonAspect` | `attachInternals({ aspects: [...] })` | AOP precedent; implies cross-cutting concern; but AOP connotations may mislead |
-| **role** | `HTMLSubmitButtonRole` | `attachInternals({ roles: [...] })` | Intuitive for "what the element does"; **conflicts with ARIA `role`** |
-
-> **Open question:** Is there a better name than "behavior" for this concept? The ideal name should be short, unambiguous, easy to spell, and convey "a composable unit of element functionality." Feedback on naming preferences is welcome.
+| **mixin** | `HTMLSubmitButtonMixin` | `attachInternals({ mixins: [...] })` | Related term, familiar concept but implies class-level composition |
+| **conduct** | `HTMLSubmitButtonConduct` | `attachInternals({ conducts: [...] })` | Short |
+| **action** | `HTMLSubmitButtonAction` | `attachInternals({ actions: [...] })` | Intuitive but overloaded (form `action` attribute) |
+| **trait** | `HTMLSubmitButtonTrait` | `attachInternals({ traits: [...] })` | Related term and short |
 
 ## Alternatives considered
 

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -270,7 +270,7 @@ this._internals.behaviors.htmlSubmitButton.formAction = '/custom';
 - Less setup code as developers don't manage behavior instances.
 
 **Cons:**
-- Less flexible: can't configure behavior before attachment.
+- Platform instantiates the behavior, so constructor parameters aren't available.
 - Requires a `behaviors` interface for named access.
 - *Future* developer-defined behaviors would need a way to name their behaviors.
 
@@ -445,7 +445,33 @@ There can be two interpretations of what "compatible behaviors" means:
 - May block legitimate use cases that weren't anticipated.
 - Must still be combined with Alternative 1 or 3 when compatible behaviors have overlapping capabilities.
 
-#### Alternative 3: Explicit conflict resolution
+#### Alternative 3: Event-handled flag (first-to-handle wins)
+
+Rather than enforcing a fixed precedence order, all behaviors' event handlers run, but each handler checks whether the event has already been "handled" by a previous behavior. The first behavior to handle the event marks it as handled; subsequent behaviors see this flag and skip their logic. This is similar to how Gecko internally manages default actions using a "handled" flag separate from `defaultPrevented`.
+
+```javascript
+// Conceptual model (platform-internal, not author-facing):
+for (const behavior of element.behaviors) {
+  if (!event._handled) {
+    behavior.handleActivation(event);
+  }
+}
+```
+
+This approach decouples the resolution from array ordering. The order in which behaviors execute may be arbitrary (or spec-defined), but only the first behavior to claim the event "wins." For properties like ARIA role, a separate resolution mechanism (e.g., last-in-wins or explicit author override) is still needed.
+
+**Pros:**
+- All behaviors get a chance to inspect the event; none are silently skipped.
+- More flexible than strict ordering: a behavior can conditionally choose not to handle an event, allowing a later behavior to take over.
+- Aligns with Gecko's existing internal model.
+- Doesn't preclude novel interplay between behaviors (e.g., a behavior could modify event state before passing it along).
+
+**Cons:**
+- The "handled" flag is a new concept that authors and spec editors must reason about—it's distinct from `defaultPrevented` and `stopPropagation`.
+- For properties (role, disabled), this pattern doesn't naturally apply; a separate resolution strategy is still needed.
+- Arbitrary execution order may make behavior harder to reason about unless the spec defines a deterministic order.
+
+#### Alternative 4: Explicit conflict resolution
 
 If conflicts occur, the platform requires the author to explicitly resolve them. This applies to properties, methods, and event handlers:
 
@@ -500,11 +526,15 @@ This proposal supports common web component patterns:
 ### Use case: Design system button
 
 While this proposal only introduces `HTMLSubmitButtonBehavior`, the example below references `HTMLResetButtonBehavior` and `HTMLButtonBehavior` to illustrate how switching would work once additional behaviors become available in the future.
+
+#### Approach A: Single behavior, determined at connection time
+
 A design system can use delayed `attachInternals()` to determine the behavior based on the initial `type` attribute. This approach uses a single class while keeping behaviors immutable after attachment.
 
 ```javascript
 class DesignSystemButton extends HTMLElement {
     static formAssociated = true;
+    static observedAttributes = ['type', 'disabled', 'formaction'];
 
     // Behavior reference (set once in connectedCallback).
     #behavior = null;
@@ -525,41 +555,52 @@ class DesignSystemButton extends HTMLElement {
         this.#render();
     }
 
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (!this.#behavior) return;
+
+        switch (name) {
+            case 'type':
+                // Type changes after connection are intentionally ignored.
+                // The behavior was determined at first connection and is immutable.
+                // This diverges from native <button> where type= can change at any time.
+                console.warn('ds-button: type attribute changes after connection have no effect.');
+                break;
+            case 'disabled':
+                this.#behavior.disabled = newValue !== null;
+                break;
+            case 'formaction':
+                if ('formAction' in this.#behavior) {
+                    this.#behavior.formAction = newValue ?? '';
+                }
+                break;
+        }
+    }
+
     #createBehaviorForType(type) {
         switch (type) {
-            case 'submit': {
-                return new HTMLSubmitButtonBehavior();
-            }
-            case 'reset': {
-                return new HTMLResetButtonBehavior();
-            }
-            default: {
-                return new HTMLButtonBehavior();
-            }
+            case 'submit': return new HTMLSubmitButtonBehavior();
+            case 'reset': return new HTMLResetButtonBehavior();
+            default: return new HTMLButtonBehavior();
         }
     }
 
     // Expose behavior properties.
-    get disabled() {
-      return this.#behavior.disabled;
-    }
+    get disabled() { return this.#behavior?.disabled ?? false; }
     set disabled(val) {
-      this.#behavior.disabled = val;
+        if (this.#behavior) this.#behavior.disabled = val;
+        this.toggleAttribute('disabled', val);
     }
 
-    get formAction() { 
-        // Only submit buttons have `formAction`.
-        return this.#behavior.formAction ?? ''; 
-    }
-    set formAction(val) { 
-        if ('formAction' in this.#behavior) {
-            this.#behavior.formAction = val; 
+    get formAction() { return this.#behavior?.formAction ?? ''; }
+    set formAction(val) {
+        if (this.#behavior && 'formAction' in this.#behavior) {
+            this.#behavior.formAction = val;
         }
     }
 
-    // Additional getters/setters for `disabled`, `formMethod`, `formEnctype`,
-    // `formNoValidate`, `formTarget`, `name`, and `value` would follow the
-    // same pattern.
+    // Additional getters/setters for formMethod, formEnctype,
+    // formNoValidate, formTarget, name, and value would follow
+    // the same pattern.
 
     #render() {
         const isSubmit = this.#behavior instanceof HTMLSubmitButtonBehavior;
@@ -576,7 +617,96 @@ class DesignSystemButton extends HTMLElement {
 }
 customElements.define('ds-button', DesignSystemButton);
 ```
-*Note: Changing the `type` attribute after the element connects has no effect on behavior. The type is determined once at connection time.*
+
+*Note: Changing the `type` attribute after the element connects has no effect on behavior. The behavior is determined once at first connection time. This is a deliberate trade-off: it simplifies the mental model at the cost of diverging from native `<button>`, where `type=` can change at any time.*
+
+#### Approach B: All behaviors loaded, activation determined by type
+
+An alternative approach loads all three button behaviors at once and uses a `type` property to control which one is active. This mirrors native `<button>` more closely since `type=` can change at any time:
+
+```javascript
+class DesignSystemButton extends HTMLElement {
+    static formAssociated = true;
+    static observedAttributes = ['type', 'disabled', 'formaction'];
+
+    #submitBehavior = new HTMLSubmitButtonBehavior();
+    #resetBehavior = new HTMLResetButtonBehavior();
+    #buttonBehavior = new HTMLButtonBehavior();
+    #internals = null;
+    #type = 'button';
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: "open" });
+        this.#internals = this.attachInternals({
+            behaviors: [this.#submitBehavior, this.#resetBehavior, this.#buttonBehavior]
+        });
+    }
+
+    connectedCallback() {
+        this.#type = this.getAttribute('type') || 'button';
+        this.#syncDisabledState();
+        this.#render();
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        switch (name) {
+            case 'type':
+                this.#type = newValue || 'button';
+                this.#syncDisabledState();
+                this.#render();
+                break;
+            case 'disabled':
+                this.#syncDisabledState();
+                break;
+            case 'formaction':
+                this.#submitBehavior.formAction = newValue ?? '';
+                break;
+        }
+    }
+
+    #syncDisabledState() {
+        const isDisabled = this.hasAttribute('disabled');
+        // Disable all non-active behaviors so they don't respond to activation.
+        this.#submitBehavior.disabled = isDisabled || this.#type !== 'submit';
+        this.#resetBehavior.disabled = isDisabled || this.#type !== 'reset';
+        this.#buttonBehavior.disabled = isDisabled || this.#type !== 'button';
+    }
+
+    get type() { return this.#type; }
+    set type(val) { this.setAttribute('type', val); }
+
+    get disabled() { return this.hasAttribute('disabled'); }
+    set disabled(val) { this.toggleAttribute('disabled', val); }
+
+    #render() {
+        const isSubmit = this.#type === 'submit';
+        const isReset = this.#type === 'reset';
+
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host { display: inline-block; padding: 8px 16px; cursor: pointer; }
+                :host(:disabled) { opacity: 0.5; cursor: not-allowed; }
+            </style>
+            ${isSubmit ? '💾' : isReset ? '🔄' : ''} <slot></slot>
+        `;
+    }
+}
+customElements.define('ds-button', DesignSystemButton);
+```
+
+This approach uses `disabled` on non-active behaviors to prevent them from responding to events. Changing `type=` at any time switches which behavior is active, matching native `<button>` semantics.
+
+**Trade-offs:**
+
+| | Approach A (single behavior) | Approach B (all behaviors) |
+|--|--|--|
+| `type=` changes | Ignored after connection | Supported at any time |
+| Memory | One behavior instance | Three behavior instances |
+| Complexity | Simpler | Must manage disabled state across behaviors |
+| Native `<button>` parity | Diverges (type is fixed) | Closer match |
+| Conflict resolution | Not needed (single behavior) | Needs care: all behaviors attached, only one active |
+
 ```html
 <form action="/save" method="post">
     <input name="username" required>
@@ -758,6 +888,102 @@ Future behaviors would also manage their own relevant pseudo-classes:
 | `HTMLInputBehavior` | `:valid`, `:invalid`, `:required`, `:optional`, `:placeholder-shown` |
 | `HTMLRadioGroupBehavior` | `:checked` |
 | `HTMLResetButtonBehavior` | `:default` (if only reset button in form) |
+
+### PlatformBehavior API surface
+
+The `PlatformBehavior` base class provides the following capabilities to both platform-provided and (future) developer-defined behaviors:
+
+| Member | Kind | Description |
+|--------|------|-------------|
+| `element` | Property (read-only) | Reference to the host element. Set automatically when the behavior is attached. |
+| `setDefaultRole(role)` | Method | Sets the element's implicit ARIA role (reflected by `ElementInternals.role`). Multiple behaviors can call this; conflict resolution determines which role wins. |
+| `setDefaultTabIndex(index)` | Method | Sets the element's implicit tab index, making it focusable without an explicit `tabindex` attribute. |
+| `behaviorAttachedCallback(internals)` | Lifecycle | Called when the behavior is attached to an element via `attachInternals()`. Receives the `ElementInternals` object. |
+| `behaviorDetachedCallback()` | Lifecycle | Called when the behavior is detached or the element is disconnected. |
+| `behaviorAttributeChangedCallback(name, oldValue, newValue)` | Lifecycle | *(Under consideration)* Called when an observed attribute changes. See [Attribute change monitoring](#attribute-change-monitoring). |
+| `disabled` | Property | Gets/sets whether the behavior is disabled. When `true`, the behavior does not respond to activation events and the element matches `:disabled`. |
+
+> **Note:** The exact surface of `PlatformBehavior` is still being refined. The table above represents the current thinking and is subject to change based on feedback and implementation experience.
+
+#### Userland HTMLButtonBehavior sketch
+
+To validate that the API surface is sufficient, here is a sketch of how `HTMLButtonBehavior` (the plain `type="button"` behavior) might be implemented in userland. This exercise helps identify gaps in the base class:
+
+```javascript
+class HTMLButtonBehaviorSketch extends PlatformBehavior {
+  // Internal state.
+  #disabled = false;
+  #internals = null;
+  #name = '';
+  #value = '';
+
+  behaviorAttachedCallback(internals) {
+    this.#internals = internals;
+
+    // Set defaults: focusable and role="button".
+    this.setDefaultRole('button');
+    this.setDefaultTabIndex(0);
+
+    // Handle activation (click + keyboard).
+    this.element.addEventListener('click', this.#handleClick);
+    this.element.addEventListener('keydown', this.#handleKeydown);
+    this.element.addEventListener('keyup', this.#handleKeyup);
+  }
+
+  behaviorDetachedCallback() {
+    this.element.removeEventListener('click', this.#handleClick);
+    this.element.removeEventListener('keydown', this.#handleKeydown);
+    this.element.removeEventListener('keyup', this.#handleKeyup);
+    this.#internals = null;
+  }
+
+  // Activation behavior: for type="button" there is no default action,
+  // but the element should still be activatable and fire click events.
+  #handleClick = (e) => {
+    if (this.#disabled) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
+  };
+
+  #handleKeydown = (e) => {
+    if (this.#disabled) return;
+    // Space and Enter activate buttons.
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      if (e.key === 'Enter') {
+        this.element.click();
+      }
+    }
+  };
+
+  #handleKeyup = (e) => {
+    if (this.#disabled) return;
+    if (e.key === ' ') {
+      this.element.click();
+    }
+  };
+
+  get disabled() { return this.#disabled; }
+  set disabled(val) {
+    this.#disabled = Boolean(val);
+    // Reflects to :disabled pseudo-class via internals.
+    this.#internals?.setDisabled?.(this.#disabled);
+  }
+
+  get name() { return this.#name; }
+  set name(val) { this.#name = val; }
+
+  get value() { return this.#value; }
+  set value(val) { this.#value = val; }
+}
+```
+
+**Observations from this exercise:**
+- The sketch reveals that `PlatformBehavior` needs to provide a way to affect the `:disabled` pseudo-class. The `setDisabled()` method (or a `disabled` property on the base class) would need to integrate with `ElementInternals` states.
+- Keyboard activation follows the [ARIA button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/): Enter fires immediately on keydown, Space fires on keyup. A native behavior wouldn't need to add event listeners—it would hook into the browser's activation algorithm directly.
+- A userland behavior must manage its own event listeners, whereas a native behavior hooks into the UA's event dispatch. This means userland behaviors may not perfectly replicate native timing (e.g., a native button's click fires during the activation behavior step, not during normal event dispatch).
+- The `type="button"` behavior is deliberately simple: it provides focusability, role, and keyboard activation but has no form submission or reset semantics.
 
 ### Developer-defined behaviors
 
@@ -1029,6 +1255,131 @@ This proposal uses static behaviors: once attached via `attachInternals()`, beha
 For behaviors, the same problems would apply: if behaviors could be swapped dynamically, authors would need to handle state migration, event handler cleanup, and property compatibility.
 
 If compelling use cases emerge that genuinely require dynamic behavior composition, the API could be extended to use `ObservableArray` with lifecycle callbacks. This would be a backwards-compatible change (making the array mutable doesn't break code that treats it as read-only). However, we believe static behaviors will cover the vast majority of real-world needs.
+
+### Attribute change monitoring
+
+<a id="attribute-change-monitoring"></a>
+
+Behaviors often need to respond to attribute changes on their host element. For example, a submit button behavior needs to react when `formaction` changes; a checkbox behavior needs to react when `checked` changes. Currently, this requires one of two approaches, each with drawbacks:
+
+#### Current approach: Manual forwarding from `attributeChangedCallback`
+
+The custom element author explicitly forwards attribute changes to the behavior:
+
+```javascript
+class DesignSystemButton extends HTMLElement {
+    static observedAttributes = ['disabled', 'formaction'];
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        if (name === 'disabled') {
+            this._submitBehavior.disabled = newValue !== null;
+        } else if (name === 'formaction') {
+            this._submitBehavior.formAction = newValue ?? '';
+        }
+    }
+}
+```
+
+**Pros:**
+- Authors have full control over which attributes map to which behavior properties.
+- No new API needed.
+
+**Cons:**
+- Boilerplate: Every attribute the behavior cares about must be manually forwarded.
+- Error-prone: Authors can forget to forward an attribute, leading to subtle bugs.
+- Coupling: The custom element must know which attributes each behavior needs.
+
+#### Alternative: MutationObserver inside the behavior
+
+A behavior could observe its own element's attributes:
+
+```javascript
+class SubmitBehavior extends PlatformBehavior {
+    #observer = null;
+
+    behaviorAttachedCallback(internals) {
+        this.#observer = new MutationObserver(mutations => {
+            for (const m of mutations) {
+                if (m.attributeName === 'formaction') {
+                    this.formAction = this.element.getAttribute('formaction') ?? '';
+                }
+            }
+        });
+        this.#observer.observe(this.element, { attributes: true });
+    }
+
+    behaviorDetachedCallback() {
+        this.#observer?.disconnect();
+    }
+}
+```
+
+**Pros:**
+- The behavior is self-contained—no manual forwarding needed.
+
+**Cons:**
+- `MutationObserver` is asynchronous (microtask-based), which means attribute changes are not observed synchronously. This can cause flickering or missed intermediate states.
+- Performance overhead: creating an observer per behavior per element is wasteful.
+- Ergonomic mismatch: `MutationObserver` was designed for DOM observation, not for component-internal attribute routing.
+
+#### Potential solution: `behaviorAttributeChangedCallback`
+
+A dedicated callback, analogous to the custom element's `attributeChangedCallback`, could allow behaviors to declare which attributes they observe:
+
+```javascript
+class SubmitBehaviorSketch extends PlatformBehavior {
+    static observedAttributes = ['formaction', 'formmethod', 'formenctype',
+                                 'formnovalidate', 'formtarget', 'disabled'];
+
+    behaviorAttributeChangedCallback(name, oldValue, newValue) {
+        switch (name) {
+            case 'disabled':
+                this.disabled = newValue !== null;
+                break;
+            case 'formaction':
+                this.formAction = newValue ?? '';
+                break;
+            // ... other attribute mappings.
+        }
+    }
+}
+```
+
+**Pros:**
+- Synchronous, like `attributeChangedCallback`.
+- Behaviors are self-contained: they declare what they need and react to it.
+- No MutationObserver overhead.
+- Mirrors the familiar `observedAttributes` / `attributeChangedCallback` pattern.
+
+**Cons:**
+- New lifecycle callback to implement and specify.
+- Potential ordering question: does the element's `attributeChangedCallback` fire before or after the behavior's `behaviorAttributeChangedCallback`?
+- If both the element and the behavior respond to the same attribute, there may be redundant processing.
+
+> **Open question:** Should `behaviorAttributeChangedCallback` be part of the initial proposal, or deferred to a later iteration? Platform-provided behaviors like `HTMLSubmitButtonBehavior` already embed their attribute observation in native code, so this callback is primarily needed for developer-defined behaviors and polyfills.
+
+### Naming: "behavior" vs alternatives
+
+The word "behavior" has been used throughout this proposal, but it has some drawbacks:
+
+- **Spelling:** "behaviour" (British) vs "behavior" (American) is a common source of confusion in codebases with international contributors. APIs with regional spelling variants (e.g., `colour` vs `color` in CSS) are a known pain point.
+- **Length:** `HTMLSubmitButtonBehavior` is 25 characters. Shorter names would improve ergonomics, especially given how frequently these names appear in code.
+- **Overloaded:** "Behavior" is used in many other contexts (CSS scroll-behavior, HTC behaviors in legacy IE, BehaviorSubject in RxJS), which could cause confusion.
+
+Alternative names under consideration:
+
+| Name | Example class | Example API | Notes |
+|------|--------------|-------------|-------|
+| **behavior** (current) | `HTMLSubmitButtonBehavior` | `attachInternals({ behaviors: [...] })` | Clear meaning; spelling/length concerns |
+| **trait** | `HTMLSubmitButtonTrait` | `attachInternals({ traits: [...] })` | Short; Rust/Scala precedent for composable units; may confuse Rust developers (traits are interfaces, not instances in Rust) |
+| **facet** | `HTMLSubmitButtonFacet` | `attachInternals({ facets: [...] })` | Short; implies "one aspect of a larger whole"; less common in programming |
+| **mixin** | `HTMLSubmitButtonMixin` | `attachInternals({ mixins: [...] })` | Familiar concept; but "mixin" implies class-level composition (inheritance), not instance-level |
+| **cap** (capability) | `HTMLSubmitButtonCap` | `attachInternals({ caps: [...] })` | Very short; "capability" is well-understood; but "cap" is ambiguous on its own |
+| **feature** | `HTMLSubmitButtonFeature` | `attachInternals({ features: [...] })` | Intuitive; but "feature" is very generic and overloaded in web specs (Feature Policy, `@supports`) |
+| **aspect** | `HTMLSubmitButtonAspect` | `attachInternals({ aspects: [...] })` | AOP precedent; implies cross-cutting concern; but AOP connotations may mislead |
+| **role** | `HTMLSubmitButtonRole` | `attachInternals({ roles: [...] })` | Intuitive for "what the element does"; **conflicts with ARIA `role`** |
+
+> **Open question:** Is there a better name than "behavior" for this concept? The ideal name should be short, unambiguous, easy to spell, and convey "a composable unit of element functionality." Feedback on naming preferences is welcome.
 
 ## Alternatives considered
 

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -144,27 +144,27 @@ Each behavior exposes properties and methods from its corresponding native eleme
 
 ```javascript
 class CustomSubmitButton extends HTMLElement {
-    constructor() {
-        super();
-        this._submitBehavior = new HTMLSubmitButtonBehavior();
-        this._internals = this.attachInternals({ behaviors: [this._submitBehavior] });
-    }
+  constructor() {
+    super();
+    this._submitBehavior = new HTMLSubmitButtonBehavior();
+    this._internals = this.attachInternals({ behaviors: [this._submitBehavior] });
+  }
 
-    get disabled() {
-        return this._submitBehavior.disabled;
-    }
+  get disabled() {
+    return this._submitBehavior.disabled;
+  }
 
-    set disabled(val) {
-        this._submitBehavior.disabled = val;
-    }
+  set disabled(val) {
+    this._submitBehavior.disabled = val;
+  }
 
-    get formAction() {
-        return this._submitBehavior.formAction;
-    }
+  get formAction() {
+    return this._submitBehavior.formAction;
+  }
 
-    set formAction(val) {
-        this._submitBehavior.formAction = val;
-    }
+  set formAction(val) {
+    this._submitBehavior.formAction = val;
+  }
 }
 ```
 
@@ -174,18 +174,17 @@ Authors are also responsible for attribute reflection. If the author wants HTML 
 
 ```javascript
 class CustomButton extends HTMLElement {
-    static observedAttributes = ['disabled', 'formaction'];
+  static observedAttributes = ['disabled', 'formaction'];
 
-    attributeChangedCallback(name, oldValue, newValue) {
-        if (name === 'disabled') {
-            this._submitBehavior.disabled = newValue !== null;
-        } else if (name === 'formaction') {
-            this._submitBehavior.formAction = newValue ?? '';
-        }
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (name === 'disabled') {
+      this._submitBehavior.disabled = newValue !== null;
+    } else if (name === 'formaction') {
+      this._submitBehavior.formAction = newValue ?? '';
     }
+  }
 }
 ```
-*Note: platform-provided behaviors handle their internal attribute observation. For example, when the platform triggers form submission, `HTMLSubmitButtonBehavior` uses the current `formAction` value without any author intervention. The forwarding step above is only needed to connect HTML attributes on the custom element to the behavior's properties.*
 
 ### Behavior lifecycle
 
@@ -448,7 +447,7 @@ this.attachInternals({
 There can be two interpretations of what "compatible behaviors" means:
 
 1. Compatible behaviors have completely disjoint capabilities (e.g., one provides `disabled`, the other provides `href`). No conflict resolution is needed because they never touch the same property or event.
-2. Compatible behaviors may share some capabilities (e.g., both provide a role or handle click). In this case, a conflict resolution strategy (Alternative 1) is still required for overlapping capabilities.
+2. Compatible behaviors may share some capabilities (e.g., both provide a role or handle click). In this case, a conflict resolution strategy (Alternative 1 or 3) is still required for overlapping capabilities.
 
 **Pros:**
 - Prevents nonsensical combinations at attachment time.
@@ -459,7 +458,7 @@ There can be two interpretations of what "compatible behaviors" means:
 - More restrictive as authors can't experiment with novel combinations.
 - Requires the platform to update compatibility lists.
 - May block legitimate use cases that weren't anticipated.
-- Must still be combined with Alternative 1 when compatible behaviors have overlapping capabilities.
+- Must still be combined with Alternative 1 or 3 when compatible behaviors have overlapping capabilities.
 
 #### Alternative 3: Explicit conflict resolution
 
@@ -508,8 +507,8 @@ This proposal supports common web component patterns:
 
   ```html
   <custom-button name="custom-submit-button">
-      <element-internals behaviors="html-submit-button-behavior"></element-internals>
-      <template>Submit</template>
+    <element-internals behaviors="html-submit-button-behavior"></element-internals>
+    <template>Submit</template>
   </custom-button>
   ```
 
@@ -521,118 +520,117 @@ A design system can use delayed `attachInternals()` to determine the behavior ba
 
 ```javascript
 class DesignSystemButton extends HTMLElement {
-    static formAssociated = true;
-    static observedAttributes = ['type', 'disabled', 'formaction'];
+  static formAssociated = true;
+  static observedAttributes = ['type', 'disabled', 'formaction'];
 
-    // Behavior reference (set once in connectedCallback).
-    #behavior = null;
-    #internals = null;
+  // Behavior reference (set once in connectedCallback).
+  #behavior = null;
+  #internals = null;
 
-    constructor() {
-        super();
-        this.attachShadow({ mode: "open" });
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
+  connectedCallback() {
+    // Attach behaviors once based on initial type attribute.
+    if (!this.#internals) {
+      const type = this.getAttribute('type') || 'button';
+      this.#behavior = this.#createBehaviorForType(type);
+      this.#internals = this.attachInternals({ behaviors: [this.#behavior] });
+    }
+    this.#render();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (!this.#behavior) {
+      return;
     }
 
-    connectedCallback() {
-        // Attach behaviors once based on initial type attribute.
-        if (!this.#internals) {
-            const type = this.getAttribute('type') || 'button';
-            this.#behavior = this.#createBehaviorForType(type);
-            this.#internals = this.attachInternals({ behaviors: [this.#behavior] });
+    switch (name) {
+      case 'type': {
+        // Type changes after connection are intentionally ignored.
+        console.warn('ds-button: type attribute changes after connection have no effect.');
+        break;
+      }
+      case 'disabled': {
+        this.#behavior.disabled = newValue !== null;
+        break;
+      }
+      case 'formaction': {
+        if ('formAction' in this.#behavior) {
+          this.#behavior.formAction = newValue ?? '';
         }
-        this.#render();
+        break;
+      }
     }
+  }
 
-    attributeChangedCallback(name, oldValue, newValue) {
-        if (!this.#behavior) {
-          return;
-        }
+  #createBehaviorForType(type) {
+    switch (type) {
+      case 'submit': {
+        return new HTMLSubmitButtonBehavior();
+      }
+      case 'reset': {
+        return new HTMLResetButtonBehavior();
+      }
+      default: {
+        return new HTMLButtonBehavior();
+      }
+    }
+  }
 
-        switch (name) {
-            case 'type':
-              // Type changes after connection are intentionally ignored.
-                console.warn('ds-button: type attribute changes after connection have no effect.');
-                break;
-            case 'disabled':
-                this.#behavior.disabled = newValue !== null;
-                break;
-            case 'formaction':
-                if ('formAction' in this.#behavior) {
-                    this.#behavior.formAction = newValue ?? '';
-                }
-                break;
-        }
+  // Expose behavior properties.
+  get disabled() {
+    return this.#behavior?.disabled ?? false;
+  }
+  set disabled(val) {
+    this.toggleAttribute('disabled', val);
+  }
+  get formAction() {
+    return this.#behavior?.formAction ?? '';
+  }
+  set formAction(val) {
+    if (this.#behavior && 'formAction' in this.#behavior) {
+      this.#behavior.formAction = val;
     }
+  }
 
-    #createBehaviorForType(type) {
-        switch (type) {
-            case 'submit': {
-                return new HTMLSubmitButtonBehavior();
-            }
-            case 'reset': {
-                return new HTMLResetButtonBehavior();
-            }
-            default: {
-                return new HTMLButtonBehavior();
-            }
-        }
-    }
+  // Additional getters/setters for formMethod, formEnctype,
+  // formNoValidate, formTarget, name, and value would follow
+  // the same pattern.
 
-    // Expose behavior properties.
-    get disabled() {
-        return this.#behavior?.disabled ?? false;
-    }
-    set disabled(val) {
-        if (this.#behavior) {
-            this.#behavior.disabled = val;
-        }
-        this.toggleAttribute('disabled', val);
-    }
-    get formAction() {
-        return this.#behavior?.formAction ?? '';
-    }
-    set formAction(val) {
-        if (this.#behavior && 'formAction' in this.#behavior) {
-            this.#behavior.formAction = val;
-        }
-    }
+  #render() {
+    const isSubmit = this.#behavior instanceof HTMLSubmitButtonBehavior;
+    const isReset = this.#behavior instanceof HTMLResetButtonBehavior;
 
-    // Additional getters/setters for formMethod, formEnctype,
-    // formNoValidate, formTarget, name, and value would follow
-    // the same pattern.
-
-    #render() {
-        const isSubmit = this.#behavior instanceof HTMLSubmitButtonBehavior;
-        const isReset = this.#behavior instanceof HTMLResetButtonBehavior;
-
-        this.shadowRoot.innerHTML = `
-            <style>
-                ...
-            </style>
-            ${isSubmit ? '💾' : isReset ? '🔄' : ''} <slot></slot>
-        `;
-    }
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: inline-block; padding: 8px 16px; cursor: pointer; }
+        :host(:disabled) { opacity: 0.5; cursor: not-allowed; }
+      </style>
+      ${isSubmit ? '💾' : isReset ? '🔄' : ''} <slot></slot>
+    `;
+  }
 }
 customElements.define('ds-button', DesignSystemButton);
 ```
 
-*Note: Changing the `type` attribute after the element connects has no effect on behavior, as the behavior is determined once at first connection time.*
-
 ```html
 <form action="/save" method="post">
-    <input name="username" required>
+  <input name="username" required>
 
-    <!-- Submit button with custom form action. -->
-    <ds-button type="submit" formaction="/draft">Save Draft</ds-button>
+  <!-- Submit button with custom form action. -->
+  <ds-button type="submit" formaction="/draft">Save Draft</ds-button>
 
-    <!-- Default submit button (matches :default). -->
-    <ds-button type="submit">Save</ds-button>
+  <!-- Default submit button (matches :default). -->
+  <ds-button type="submit">Save</ds-button>
 
-    <!-- Reset button. -->
-    <ds-button type="reset">Reset</ds-button>
+  <!-- Reset button. -->
+  <ds-button type="reset">Reset</ds-button>
 
-    <!-- Regular button (default when no type specified). -->
-    <ds-button>Cancel</ds-button>
+  <!-- Regular button (default when no type specified). -->
+  <ds-button>Cancel</ds-button>
 </form>
 ```
 
@@ -648,10 +646,9 @@ The element gains:
 
 #### Dynamically changing the `type` attribute
 
-Consider `behaviors: [submitBehavior, resetBehavior, buttonBehavior]` with the intent to "disable" non-active behaviors:
+Consider `behaviors: [submitBehavior, resetBehavior, buttonBehavior]` with the intent to toggle behaviors:
 
-- Setting `behavior.disabled = true` makes the element disabled (it matches `:disabled`, is removed from the tab order, and stops receiving activation events entirely as no click or keyboard handler from any behavior runs while the element is disabled). Under last-in-wins, only `buttonBehavior.disabled` (the last in the array) determines whether the element is disabled, so setting `submitBehavior.disabled` or `resetBehavior.disabled` has no effect on the element's disabled state.
-- Properties like `name` and `value` are provided by all three behaviors, so the last behavior's values win under a last-in-wins strategy. This means `submitBehavior.name` and `submitBehavior.value` (the ones that should participate in form data) are shadowed by `buttonBehavior.name` and `buttonBehavior.value`.
+- Under last-in-wins, only `buttonBehavior`'s property values (the last in the array) determine the element's effective state. For `disabled`, this means setting `submitBehavior.disabled` or `resetBehavior.disabled` has no effect — only `buttonBehavior.disabled` controls whether the element matches `:disabled`, is removed from the tab order, and stops receiving activation events (no click or keyboard handler from any behavior runs while disabled).
 - All three behaviors register click handlers with different effects. Under strict last-in-wins (Option A), only `buttonBehavior`'s handler runs. Under additive events (Option B), all handlers run (the element would submit and reset the form on every click).
 
 Because `disabled` cannot selectively silence individual behaviors and conflict resolution applies uniformly to all attached behaviors, loading all three simultaneously and switching between them is not viable. Determining the behavior once at connection time is the recommended pattern.
@@ -810,93 +807,6 @@ Future behaviors would also manage their own relevant pseudo-classes:
 | `HTMLRadioGroupBehavior` | `:checked` |
 | `HTMLResetButtonBehavior` | `:default` (if only reset button in form) |
 
-### PlatformBehavior API surface
-
-The `PlatformBehavior` base class provides the following capabilities to both platform-provided and (future) developer-defined behaviors:
-
-| Member | Kind | Description |
-|--------|------|-------------|
-| `element` | Property (read-only) | Reference to the host element. Set automatically when the behavior is attached. |
-| `setDefaultRole(role)` | Method | Sets the element's implicit ARIA role (reflected by `ElementInternals.role`). Multiple behaviors can call this; conflict resolution determines which role wins. |
-| `setDefaultTabIndex(index)` | Method | Sets the element's implicit tab index, making it focusable without an explicit `tabindex` attribute. |
-| `behaviorAttachedCallback(internals)` | Lifecycle | Called when the behavior is attached to an element via `attachInternals()`. Receives the `ElementInternals` object. |
-| `disabled` | Property | Gets/sets whether the behavior is disabled. When `true`, the behavior does not respond to activation events and the element matches `:disabled`. |
-
-> **Note:** The exact surface of `PlatformBehavior` is still being refined. The table above represents the current thinking and is subject to change based on feedback and implementation experience.
-
-#### Userland HTMLButtonBehavior sketch
-
-To validate that the API surface is sufficient, here is a sketch of how `HTMLButtonBehavior` (the plain `type="button"` behavior) might be implemented in userland. This exercise helps identify gaps in the base class:
-
-```javascript
-class HTMLButtonBehaviorSketch extends PlatformBehavior {
-  // Internal state.
-  #disabled = false;
-  #internals = null;
-  #name = '';
-  #value = '';
-
-  behaviorAttachedCallback(internals) {
-    this.#internals = internals;
-
-    // Set defaults: focusable and role="button".
-    this.setDefaultRole('button');
-    this.setDefaultTabIndex(0);
-
-    // Handle activation (click + keyboard).
-    this.element.addEventListener('click', this.#handleClick);
-    this.element.addEventListener('keydown', this.#handleKeydown);
-    this.element.addEventListener('keyup', this.#handleKeyup);
-  }
-
-  // Activation behavior: for type="button" there is no default action,
-  // but the element should still be activatable and fire click events.
-  #handleClick = (e) => {
-    if (this.#disabled) {
-      e.stopImmediatePropagation();
-      e.preventDefault();
-    }
-  };
-
-  #handleKeydown = (e) => {
-    if (this.#disabled) return;
-    // Space and Enter activate buttons.
-    if (e.key === ' ' || e.key === 'Enter') {
-      e.preventDefault();
-      if (e.key === 'Enter') {
-        this.element.click();
-      }
-    }
-  };
-
-  #handleKeyup = (e) => {
-    if (this.#disabled) return;
-    if (e.key === ' ') {
-      this.element.click();
-    }
-  };
-
-  get disabled() { return this.#disabled; }
-  set disabled(val) {
-    this.#disabled = Boolean(val);
-    // Reflects to :disabled pseudo-class via internals.
-    this.#internals?.setDisabled?.(this.#disabled);
-  }
-
-  get name() { return this.#name; }
-  set name(val) { this.#name = val; }
-
-  get value() { return this.#value; }
-  set value(val) { this.#value = val; }
-}
-```
-
-**Observations from this exercise:**
-- The sketch reveals that `PlatformBehavior` needs to provide a way to affect the `:disabled` pseudo-class. The `setDisabled()` method (or a `disabled` property on the base class) would need to integrate with `ElementInternals` states.
-- Keyboard activation follows the [ARIA button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/): Enter fires immediately on keydown, Space fires on keyup. A native behavior wouldn't need to add event listeners—it would hook into the browser's activation algorithm directly.
-- A userland behavior must manage its own event listeners, whereas a native behavior hooks into the UA's event dispatch. This means userland behaviors may not perfectly replicate native timing (e.g., a native button's click fires during the activation behavior step, not during normal event dispatch).
-- The `type="button"` behavior is deliberately simple: it provides focusability, role, and keyboard activation but has no form submission or reset semantics.
-
 ### Developer-defined behaviors
 
 A future extension of this proposal could allow developers to define their own reusable behaviors:
@@ -961,6 +871,137 @@ class CustomButton extends HTMLElement {
 ```
 
 `TooltipBehavior` could be combined with platform-provided behaviors. Here, `CustomButton` gains both tooltip functionality (show on hover/focus) and submit button semantics (click/Enter submits forms, implicit submission, `role="button"`).
+
+#### PlatformBehavior API
+
+For developer-defined behaviors to work, `PlatformBehavior` would need to expose an API that lets web developers set accessibility defaults, receive lifecycle notifications, and reference the host element. The table below describes what the base class would need to provide for developer-defined subclasses:
+
+| Member | Kind | Description |
+|--------|------|-------------|
+| `element` | Property (read-only) | Reference to the host element. |
+| `setDefaultRole(role)` | Method | Sets the element's implicit ARIA role. |
+| `setDefaultTabIndex(index)` | Method | Sets the element's implicit tab index, making it focusable without an explicit `tabindex` attribute. |
+| `behaviorAttachedCallback(internals)` | Lifecycle | Called when the behavior is attached to an element via `attachInternals()`. Receives the `ElementInternals` object. |
+
+The following example shows how `HTMLButtonBehavior` (the plain `type="button"` behavior) would be implemented in userland:
+
+```javascript
+class HTMLButtonBehaviorExample extends PlatformBehavior {
+  #disabled = false;
+  #internals = null;
+  #name = '';
+  #value = '';
+
+  #popoverTargetElement = null;
+  #popoverTargetAction = 'toggle';
+  #commandForElement = null;
+  #command = '';
+
+  behaviorAttachedCallback(internals) {
+    this.#internals = internals;
+
+    this.setDefaultRole('button');
+    this.setDefaultTabIndex(0);
+
+    this.element.addEventListener('click', this.#handleClick);
+    this.element.addEventListener('keydown', this.#handleKeydown);
+    this.element.addEventListener('keyup', this.#handleKeyup);
+  }
+
+  #handleClick = (e) => {
+    if (this.#disabled) {
+      e.stopImmediatePropagation();
+      e.preventDefault();
+      return;
+    }
+
+    if (this.#popoverTargetElement) {
+      switch (this.#popoverTargetAction) {
+        case 'show': {
+          this.#popoverTargetElement.showPopover();
+          break;
+        }
+        case 'hide': {
+          this.#popoverTargetElement.hidePopover();
+          break;
+        }
+        default: {
+          this.#popoverTargetElement.togglePopover();
+          break;
+        }
+      }
+      return;
+    }
+
+    if (this.#commandForElement && this.#command) {
+      const commandEvent = new CommandEvent('command', {
+        source: this.element,
+        command: this.#command,
+      });
+      this.#commandForElement.dispatchEvent(commandEvent);
+    }
+  };
+
+  #handleKeydown = (e) => {
+    if (this.#disabled) {
+      return;
+    }
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      if (e.key === 'Enter') {
+        this.element.click();
+      }
+    }
+  };
+
+  #handleKeyup = (e) => {
+    if (this.#disabled) {
+      return;
+    }
+    if (e.key === ' ') {
+      this.element.click();
+    }
+  };
+
+  // Properties
+  get disabled() { return this.#disabled; }
+  set disabled(val) {
+    this.#disabled = val;
+    this.#internals?.setDisabled?.(this.#disabled);
+  }
+
+  get name() { return this.#name; }
+  set name(val) { this.#name = val; }
+
+  get value() { return this.#value; }
+  set value(val) { this.#value = val; }
+
+  // Popover target API.
+  get popoverTargetElement() { return this.#popoverTargetElement; }
+  set popoverTargetElement(val) { this.#popoverTargetElement = val; }
+  get popoverTargetAction() { return this.#popoverTargetAction; }
+  set popoverTargetAction(val) { this.#popoverTargetAction = val; }
+
+  // Invoker commands API.
+  get commandForElement() { return this.#commandForElement; }
+  set commandForElement(val) { this.#commandForElement = val; }
+  get command() { return this.#command; }
+  set command(val) { this.#command = val; }
+}
+
+// Attaching the behavior to a custom element:
+class MyButton extends HTMLElement {
+  constructor() {
+    super();
+    this._buttonBehavior = new HTMLButtonBehaviorExample();
+    this._internals = this.attachInternals({ behaviors: [this._buttonBehavior] });
+  }
+}
+```
+
+- The subclass overrides `behaviorAttachedCallback(internals)` to receive the `ElementInternals` object; set defaults with `setDefaultRole(role)` and `setDefaultTabIndex(index)`; and register event listeners.
+- The platform would set `this.element` before calling `behaviorAttachedCallback`, so it is already available inside the callback. The example uses `this.element` to register event listeners and to trigger clicks during keyboard activation.
+- `PlatformBehavior` needs to provide a way to affect the `:disabled` pseudo-class. The `setDisabled()` method (called in the `disabled` setter) would need to integrate with `ElementInternals` states.
 
 #### Polyfilling behaviors
 
@@ -1071,11 +1112,11 @@ The platform automatically adds behavior properties to the custom element:
 
 ```javascript
 class CustomSubmitButton extends HTMLElement {
-    constructor() {
-        super();
-        this._submitBehavior = new HTMLSubmitButtonBehavior();
-        this.attachInternals({ behaviors: [this._submitBehavior] });
-    }
+  constructor() {
+    super();
+    this._submitBehavior = new HTMLSubmitButtonBehavior();
+    this.attachInternals({ behaviors: [this._submitBehavior] });
+  }
 }
 
 const btn = document.createElement('custom-submit');
@@ -1115,8 +1156,8 @@ this.attachInternals({ behaviors: [this._submitBehavior] });
 // Opt-in to automatic exposure.
 this._submitBehavior = new HTMLSubmitButtonBehavior();
 this.attachInternals({ 
-    behaviors: [this._submitBehavior],
-    exposeProperties: true  // or list specific properties.
+  behaviors: [this._submitBehavior],
+  exposeProperties: true  // or list specific properties.
 });
 ```
 
@@ -1156,7 +1197,7 @@ If compelling use cases emerge that genuinely require dynamic behavior compositi
 
 ### Is there a better name than "behavior" for this concept?
 
-The word "behavior" has some drawbacks:
+The American English spelling of behavior throughout this proposal follows the [WHATWG spec style guidelines](https://wiki.whatwg.org/wiki/Specs/style#:~:text=Use%20standard%20American%20English%20spelling). However, the word "behavior" has some drawbacks:
 
 - "behaviour" vs "behavior" may cause some friction for contributors.
 - Shorter names would improve ergonomics.
@@ -1198,12 +1239,12 @@ Set a single "type" string that grants a predefined bundle of behaviors.
 
 ```javascript
 class CustomButton extends HTMLElement {
-    static formAssociated = true;
+  static formAssociated = true;
 
-    constructor() {
-        super();
-        this.attachInternals().type = 'button';
-    }
+  constructor() {
+    super();
+    this.attachInternals().type = 'button';
+  }
 }
 ```
 
@@ -1224,11 +1265,11 @@ Define custom attributes with lifecycle callbacks that add behavior to elements.
 
 ```javascript
 class SubmitButtonAttribute extends Attribute {
-    connectedCallback() {
-        this.ownerElement.addEventListener('click', () => {
-            // Submit form logic.
-        });
-    }
+  connectedCallback() {
+    this.ownerElement.addEventListener('click', () => {
+      // Submit form logic.
+    });
+  }
 }
 HTMLElement.attributeRegistry.define('submit-button', SubmitButtonAttribute);
 ```
@@ -1257,9 +1298,9 @@ Extend native element classes directly.
 
 ```javascript
 class FancyButton extends HTMLButtonElement {
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 }
 customElements.define('fancy-button', FancyButton, { extends: 'button' });
 ```

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -570,13 +570,13 @@ class DesignSystemButton extends HTMLElement {
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
-        if (!this.#behavior) return;
+        if (!this.#behavior) {
+          return;
+        }
 
         switch (name) {
             case 'type':
-                // Type changes after connection are intentionally ignored.
-                // The behavior was determined at first connection and is immutable.
-                // This diverges from native <button> where type= can change at any time.
+              // Type changes after connection are intentionally ignored.
                 console.warn('ds-button: type attribute changes after connection have no effect.');
                 break;
             case 'disabled':
@@ -592,20 +592,28 @@ class DesignSystemButton extends HTMLElement {
 
     #createBehaviorForType(type) {
         switch (type) {
-            case 'submit': return new HTMLSubmitButtonBehavior();
-            case 'reset': return new HTMLResetButtonBehavior();
-            default: return new HTMLButtonBehavior();
+            case 'submit':
+                return new HTMLSubmitButtonBehavior();
+            case 'reset':
+                return new HTMLResetButtonBehavior();
+            default:
+                return new HTMLButtonBehavior();
         }
     }
 
     // Expose behavior properties.
-    get disabled() { return this.#behavior?.disabled ?? false; }
+    get disabled() {
+        return this.#behavior?.disabled ?? false;
+    }
     set disabled(val) {
-        if (this.#behavior) this.#behavior.disabled = val;
+        if (this.#behavior) {
+            this.#behavior.disabled = val;
+        }
         this.toggleAttribute('disabled', val);
     }
-
-    get formAction() { return this.#behavior?.formAction ?? ''; }
+    get formAction() {
+        return this.#behavior?.formAction ?? '';
+    }
     set formAction(val) {
         if (this.#behavior && 'formAction' in this.#behavior) {
             this.#behavior.formAction = val;
@@ -622,8 +630,7 @@ class DesignSystemButton extends HTMLElement {
 
         this.shadowRoot.innerHTML = `
             <style>
-                :host { display: inline-block; padding: 8px 16px; cursor: pointer; }
-                :host(:disabled) { opacity: 0.5; cursor: not-allowed; }
+                ...
             </style>
             ${isSubmit ? '💾' : isReset ? '🔄' : ''} <slot></slot>
         `;
@@ -633,20 +640,6 @@ customElements.define('ds-button', DesignSystemButton);
 ```
 
 *Note: Changing the `type` attribute after the element connects has no effect on behavior, as the behavior is determined once at first connection time.*
-
-#### Why not load all three behaviors?
-
-An alternative approach — loading all three button behaviors at once and toggling which one is "active" via the `disabled` property — initially seems appealing because it would allow `type=` to change at any time, matching native `<button>`. However, this approach has fundamental problems due to how `disabled` and conflict resolution interact.
-
-Consider `behaviors: [submitBehavior, resetBehavior, buttonBehavior]` with the intent to "disable" non-active behaviors:
-
-**`disabled` is user-facing, not behavior-scoping.** Setting `behavior.disabled = true` makes the *element* disabled — greyed out, removed from tab order, unable to accept clicks. It doesn't mean "this behavior is inactive while others remain active." There is no per-behavior activation toggle; `disabled` is a property of the element's interaction state. Under last-in-wins, `buttonBehavior.disabled` (the last in the array) determines whether the element is disabled, regardless of what the other behaviors' `disabled` values are set to.
-
-**Property collisions under last-in-wins.** Properties like `name` and `value` are provided by all three behaviors, so the last behavior's values win. This means `submitBehavior.name` and `submitBehavior.value` — the ones that should participate in form data — are shadowed by `buttonBehavior.name` and `buttonBehavior.value`.
-
-**Event handler collisions.** All three behaviors register click handlers with different effects (submit form, reset form, do nothing). Under strict last-in-wins (Option A), only `buttonBehavior`'s handler runs — the element can never submit or reset. Under additive events (Option B), all handlers run simultaneously — the element would submit *and* reset the form on every click. Under the event-handled flag (Alternative 3), the first behavior to handle the click wins, making it impossible to switch the effective behavior without reordering the array.
-
-Because `disabled` cannot selectively silence individual behaviors and conflict resolution applies uniformly to all attached behaviors, loading all three simultaneously and switching between them is not viable. Determining the behavior once at connection time — as shown above — is the recommended pattern.
 
 ```html
 <form action="/save" method="post">
@@ -675,6 +668,16 @@ The element gains:
 - CSS pseudo-class matching: `:default`, `:disabled`/`:enabled`.
 - Participation in implicit form submission (for submit buttons).
 - Behavior properties like `disabled` and `formAction` are accessible via the stored behavior reference.
+
+#### Dynamically changing the `type` attribute
+
+Consider `behaviors: [submitBehavior, resetBehavior, buttonBehavior]` with the intent to "disable" non-active behaviors:
+
+- Setting `behavior.disabled = true` makes the element disabled (it matches `:disabled`, is removed from the tab order, and stops receiving activation events entirely as no click or keyboard handler from any behavior runs while the element is disabled). Under last-in-wins, only `buttonBehavior.disabled` (the last in the array) determines whether the element is disabled, so setting `submitBehavior.disabled` or `resetBehavior.disabled` has no effect on the element's disabled state.
+- Properties like `name` and `value` are provided by all three behaviors, so the last behavior's values win under a last-in-wins strategy. This means `submitBehavior.name` and `submitBehavior.value` (the ones that should participate in form data) are shadowed by `buttonBehavior.name` and `buttonBehavior.value`.
+- All three behaviors register click handlers with different effects. Under strict last-in-wins (Option A), only `buttonBehavior`'s handler runs. Under additive events (Option B), all handlers run (the element would submit and reset the form on every click).
+
+Because `disabled` cannot selectively silence individual behaviors and conflict resolution applies uniformly to all attached behaviors, loading all three simultaneously and switching between them is not viable. Determining the behavior once at connection time is the recommended pattern.
 
 ### Framework use cases
 

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -448,7 +448,7 @@ this.attachInternals({
 There can be two interpretations of what "compatible behaviors" means:
 
 1. Compatible behaviors have completely disjoint capabilities (e.g., one provides `disabled`, the other provides `href`). No conflict resolution is needed because they never touch the same property or event.
-2. Compatible behaviors may share some capabilities (e.g., both provide a role or handle click). In this case, a conflict resolution strategy (Alternative 1 or 3) is still required for overlapping capabilities.
+2. Compatible behaviors may share some capabilities (e.g., both provide a role or handle click). In this case, a conflict resolution strategy (Alternative 1) is still required for overlapping capabilities.
 
 **Pros:**
 - Prevents nonsensical combinations at attachment time.
@@ -459,35 +459,9 @@ There can be two interpretations of what "compatible behaviors" means:
 - More restrictive as authors can't experiment with novel combinations.
 - Requires the platform to update compatibility lists.
 - May block legitimate use cases that weren't anticipated.
-- Must still be combined with Alternative 1 or 3 when compatible behaviors have overlapping capabilities.
+- Must still be combined with Alternative 1 when compatible behaviors have overlapping capabilities.
 
-#### Alternative 3: Event-handled flag (first-to-handle wins)
-
-Rather than enforcing a fixed precedence order, all behaviors' event handlers run, but each handler checks whether the event has already been "handled" by a previous behavior. The first behavior to handle the event marks it as handled; subsequent behaviors see this flag and skip their logic. This is similar to how Gecko internally manages default actions using a "handled" flag separate from `defaultPrevented`.
-
-```javascript
-// Conceptual model (platform-internal, not author-facing):
-for (const behavior of element.behaviors) {
-  if (!event._handled) {
-    behavior.handleActivation(event);
-  }
-}
-```
-
-This approach decouples the resolution from array ordering. The order in which behaviors execute may be arbitrary (or spec-defined), but only the first behavior to claim the event "wins." For properties like ARIA role, a separate resolution mechanism (e.g., last-in-wins or explicit author override) is still needed.
-
-**Pros:**
-- All behaviors get a chance to inspect the event; none are silently skipped.
-- More flexible than strict ordering: a behavior can conditionally choose not to handle an event, allowing a later behavior to take over.
-- Aligns with Gecko's existing internal model.
-- Doesn't preclude novel interplay between behaviors (e.g., a behavior could modify event state before passing it along).
-
-**Cons:**
-- The "handled" flag is a new concept that authors and spec editors must reason about—it's distinct from `defaultPrevented` and `stopPropagation`.
-- For properties (role, disabled), this pattern doesn't naturally apply; a separate resolution strategy is still needed.
-- Arbitrary execution order may make behavior harder to reason about unless the spec defines a deterministic order.
-
-#### Alternative 4: Explicit conflict resolution
+#### Alternative 3: Explicit conflict resolution
 
 If conflicts occur, the platform requires the author to explicitly resolve them. This applies to properties, methods, and event handlers:
 
@@ -592,12 +566,15 @@ class DesignSystemButton extends HTMLElement {
 
     #createBehaviorForType(type) {
         switch (type) {
-            case 'submit':
+            case 'submit': {
                 return new HTMLSubmitButtonBehavior();
-            case 'reset':
+            }
+            case 'reset': {
                 return new HTMLResetButtonBehavior();
-            default:
+            }
+            default: {
                 return new HTMLButtonBehavior();
+            }
         }
     }
 

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -812,7 +812,7 @@ Future behaviors would also manage their own relevant pseudo-classes:
 A future extension of this proposal could allow developers to define their own reusable behaviors:
 
 ```javascript
-class TooltipBehavior extends PlatformBehavior {
+class TooltipBehavior extends ElementBehavior {
   #content = '';
   #tooltipElement = null;
 
@@ -872,9 +872,9 @@ class CustomButton extends HTMLElement {
 
 `TooltipBehavior` could be combined with platform-provided behaviors. Here, `CustomButton` gains both tooltip functionality (show on hover/focus) and submit button semantics (click/Enter submits forms, implicit submission, `role="button"`).
 
-#### PlatformBehavior API
+#### ElementBehavior API
 
-For developer-defined behaviors to work, `PlatformBehavior` would need to expose an API that lets web developers set accessibility defaults, receive lifecycle notifications, and reference the host element:
+For developer-defined behaviors to work, `ElementBehavior` would need to expose an API that lets web developers set accessibility defaults, receive lifecycle notifications, and reference the host element:
 
 | Member | Kind | Description |
 |--------|------|-------------|
@@ -886,7 +886,7 @@ For developer-defined behaviors to work, `PlatformBehavior` would need to expose
 The following example shows how `HTMLButtonBehavior` (`type="button"`) would be implemented in userland:
 
 ```javascript
-class HTMLButtonBehaviorExample extends PlatformBehavior {
+class HTMLButtonBehaviorExample extends ElementBehavior {
   #disabled = false;
   #internals = null;
   #name = '';
@@ -1001,7 +1001,7 @@ class MyButton extends HTMLElement {
 
 - The subclass overrides `behaviorAttachedCallback(internals)` to receive the `ElementInternals` object; set defaults with `setDefaultRole(role)` and `setDefaultTabIndex(index)`; and register event listeners.
 - The platform would set `this.element` before calling `behaviorAttachedCallback`, so it is already available inside the callback. The example uses `this.element` to register event listeners and to trigger clicks during keyboard activation.
-- `PlatformBehavior` needs to provide a way to affect the `:disabled` pseudo-class. The `setDisabled()` method (called in the `disabled` setter) would need to integrate with `ElementInternals` states.
+- `ElementBehavior` needs to provide a way to affect the `:disabled` pseudo-class. The `setDisabled()` method (called in the `disabled` setter) would need to integrate with `ElementInternals` states.
 
 #### Polyfilling behaviors
 
@@ -1009,7 +1009,7 @@ This design also would enable **polyfilling** new platform behaviors before they
 
 ```javascript
 // Polyfill for HTMLDialogBehavior.
-class HTMLDialogBehaviorPolyfill extends PlatformBehavior {
+class HTMLDialogBehaviorPolyfill extends ElementBehavior {
   #open = false;
   #returnValue = '';
   #modal = false;


### PR DESCRIPTION
# Updates
- `attributeChangedCallback` clarifications with examples
- Added section `Dynamically changing the type attribute`
- Deleted mentions of `behaviorDetachedCallback` as behaviors are no longer mutable
- Added PlatformBehavior API to describe what would be needed for developer-defined behaviors
- Open question on "behaviors" name
- PlatformBehavior -> ElementBehavior
- Nits: fixing spacing of examples