### PR TITLE
Platform provided behaviors feedback 11

### DIFF
--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -79,7 +79,7 @@ This proposal is informed by:
 
 ## Proposed approach
 
-This proposal introduces a `behaviors` option to `attachInternals()`. Element behaviors are instantiated with `new` and attached via the options object. Once attached, element behaviors can't be added, removed, or replaced but the behavior instances themselves remain mutable.
+This proposal introduces a `behaviors` option to `attachInternals()`. Element behaviors are instantiated with `new` and attached via the options object. Once attached, they can't be added, removed, or replaced but the element behavior instances themselves remain mutable.
 
 ```javascript
 // Instantiate the behavior and attach it.
@@ -102,7 +102,7 @@ Platform-provided behaviors give custom elements capabilities that would otherwi
 
 - Event handling: Platform events (click, keydown, etc.) are wired up automatically using the standard DOM event infrastructure (respecting `stopPropagation`, `preventDefault`, etc.)
 - ARIA defaults: Implicit roles and properties for accessibility.
-- Focusability: The element participates in the tab order as appropriate for the behavior.
+- Focusability: The element participates in the tab order as appropriate for the element behavior.
 - CSS pseudo-classes: Behavior-specific pseudo-classes are managed by the platform.
 
 Bundling these capabilities as high-level units lets the platform provide accessible defaults, wire up events correctly, and manage pseudo-class state.
@@ -127,9 +127,9 @@ This proposal introduces `HTMLSubmitButtonBehavior`, which mirrors the submissio
 | Form-associated element outside a form | `behavior.form` returns `null`, activation is a no-op (like a native button outside a form). |
 | Non-form-associated element | `behavior.form` is `null`, activation is a no-op even inside a form. Implicit submission and `:default` don't apply. The element still gets `role="button"` and implicit focusability. |
 
-### Accessing behavior state
+### Accessing the state
 
-Each behavior exposes properties and methods from its corresponding native element. Element behaviors can be accessed directly via the stored reference. For `HTMLSubmitButtonBehavior`, the following properties are available (mirroring [`HTMLButtonElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement)):
+Each element behavior exposes properties and methods from its corresponding native element. Element behaviors can be accessed directly via the stored reference. For `HTMLSubmitButtonBehavior`, the following properties are available (mirroring [`HTMLButtonElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement)):
 
 **Properties:**
 - `disabled` - The element is effectively disabled if either `behavior.disabled` is `true` or the element is disabled via attribute or is a descendant of `<fieldset disabled>` ([spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled)).
@@ -143,7 +143,7 @@ Each behavior exposes properties and methods from its corresponding native eleme
 - `name`
 - `value`
 
-To expose properties like `disabled` or `formAction` to external code, authors define getters and setters that delegate to the behavior.
+To expose properties like `disabled` or `formAction` to external code, authors define getters and setters that delegate to the element behavior.
 
 ```javascript
 class CustomSubmitButton extends HTMLElement {
@@ -171,7 +171,7 @@ class CustomSubmitButton extends HTMLElement {
 }
 ```
 
-Authors are responsible for attribute reflection. If the author wants HTML attributes on their custom element to affect the `behavior`, they need to observe and forward those attributes using `attributeChangedCallback`:
+Authors are responsible for attribute reflection. If the author wants HTML attributes on their custom element to affect the attached element behavior, they need to observe and forward those attributes using `attributeChangedCallback`:
 
 ```javascript
 class CustomButton extends HTMLElement {
@@ -196,23 +196,23 @@ Form override values (`formAction`, `formEnctype`, `formMethod`, `formNoValidate
 | `name`, `value` | No | Only `behavior.name` and `behavior.value` are read on submission. |
 | `formaction`, `formenctype`, `formmethod`, `formtarget` | No | Only `behavior` properties are read. |
 
-### Behavior lifecycle
+### Element behavior lifecycle
 
 When `attachInternals()` is called with element behaviors, each one is attached to the element:
 
 | Event | Effect |
 |-------|--------|
-| `attachInternals()` called with behaviors | Each behavior is attached. Event handlers become active. Default ARIA role is applied unless overridden by `ElementInternals.role`. |
-| Element disconnected from DOM | Behavior state is preserved. Event handlers remain conceptually attached but inactive. |
-| Element reconnected to DOM | Event handlers become active again. Behavior state (e.g., `formAction`, `disabled`) is preserved. |
+| `attachInternals()` called with behaviors | Each element behavior is attached. Event handlers become active. Default ARIA role is applied unless overridden by `ElementInternals.role`. |
+| Element disconnected from DOM | Element behavior state is preserved. Event handlers remain conceptually attached but inactive. |
+| Element reconnected to DOM | Event handlers become active again. Element behavior state (e.g., `formAction`, `disabled`) is preserved. |
 
 *Note: Element behaviors are immutable after `attachInternals()`. Dynamic updates (adding, removing, or replacing element behaviors after attachment) are not supported, as developer feedback indicated that the problems with `<input>`'s mutable `type` attribute (state migration, event handler cleanup, property compatibility) should not be replicated.*
 
-### Duplicate behaviors
+### Duplicate element behaviors
 
-Including the same behavior instance twice in the behaviors array, or attaching multiple instances of the same behavior type to a single element, throws a `TypeError`.
+Including the same instance twice in the `behaviors` array, or attaching multiple instances of the same type to a single element, throws a `TypeError`.
 
-Throws `TypeError` due to duplicate behavior instance in the array:
+Throws `TypeError` due to duplicate instances in the array:
 ```javascript
 const sharedBehavior = new HTMLSubmitButtonBehavior();
 this._internals = this.attachInternals({
@@ -220,7 +220,7 @@ this._internals = this.attachInternals({
 });
 ```
 
-Throws if multiple instances of the same behavior type are attached to one element, even if they are separate objects:
+Throws if multiple instances of the same type are attached to one element, even if they are separate objects:
 ```javascript
 const behavior1 = new HTMLSubmitButtonBehavior();
 const behavior2 = new HTMLSubmitButtonBehavior();
@@ -228,9 +228,9 @@ this._internals = this.attachInternals({
   behaviors: [behavior1, behavior2]  // Throws `TypeError`.
 });
 ```
-This restriction exists because having two instances of the same behavior type on one element creates ambiguity.
+This restriction exists because having two instances of the same type on one element creates ambiguity.
 
-A behavior instance can only be attached to one element. Attempting to attach an already-attached instance to another element throws a `TypeError`:
+An element behavior instance can only be attached to one element. Attempting to attach an already-attached instance to another element throws a `TypeError`:
 ```javascript
 const sharedBehavior = new HTMLSubmitButtonBehavior();
 element1._internals = element1.attachInternals({ behaviors: [sharedBehavior] });
@@ -248,7 +248,7 @@ Element behaviors are instantiated with `new` and passed to `attachInternals()`:
 
 *Note: An ordered array is preferred over a set because order may be significant for [conflict resolution](#behavior-composition-and-conflict-resolution). `behaviors` uses a `FrozenArray` because element behaviors are immutable after attachment.*
 
-Developers hold direct references to their element behavior instances. This follows the [W3C design principle that classes should have constructors](https://www.w3.org/TR/design-principles/#constructors) that allow authors to create and configure instances, and it extends naturally to future developer-defined element behaviors that follow the same `new` + attach pattern.
+Developers hold direct references to their element behavior instances. This follows the [W3C design principle that classes should have constructors](https://www.w3.org/TR/design-principles/#constructors) that allow authors to create and configure instances, and it extends naturally to future developer-defined behaviors that follow the same `new` + attach pattern.
 
 *For future developer-defined behaviors:*
 
@@ -270,11 +270,11 @@ this._internals = this.attachInternals({ behaviors: [this._tooltipBehavior] });
 this._tooltipBehavior.content = 'Helpful tooltip text';
 ```
 
-### Behavior composition and conflict resolution
+### Element behavior composition and conflict resolution
 
-For the element behaviors currently under consideration and mentioned in this document (`HTMLSubmitButtonBehavior`, `HTMLButtonBehavior`, `HTMLResetButtonBehavior`, etc.), there probably isn't a practical use case for combining them. However, attaching multiple element behaviors is not prohibited. If multiple element behaviors are provided, conflicts are resolved using order of precedence: the position of behaviors in the array determines which behavior's value takes effect.
+For the element behaviors currently under consideration and mentioned in this document (`HTMLSubmitButtonBehavior`, `HTMLButtonBehavior`, `HTMLResetButtonBehavior`, etc.), there probably isn't a practical use case for combining them. However, attaching multiple element behaviors is not prohibited. If multiple element behaviors are provided, conflicts are resolved using order of precedence: the position of element behaviors in the array determines which element behavior's value takes effect.
 
-Consider the following example of behaviors that could potentially be compatible, `HTMLLabelBehavior` and `HTMLSubmitButtonBehavior`:
+Consider the following example of element behaviors that could potentially be compatible, `HTMLLabelBehavior` and `HTMLSubmitButtonBehavior`:
 
 ```javascript
 class LabeledSubmitButton extends HTMLElement {
@@ -303,34 +303,34 @@ const btn = document.createElement('labeled-submit-button');
 // The element's implicit role is "button" (from HTMLSubmitButtonBehavior, last in list).
 console.log(btn.computedRole);  // "button"
 
-// If the author sets `internals.role`, that takes precedence over all behavior defaults.
+// If the author sets `internals.role`, that takes precedence over all element behavior defaults.
 this._internals.role = 'link';
 console.log(btn.computedRole);  // "link"
 
-// However, the element is disabled if any behavior's `disabled` is `true`. When
-// disabled, the entire element is affected: all behavior default actions are blocked,
+// However, the element is disabled if any element behavior's `disabled` is `true`. When
+// disabled, the entire element is affected: all element behavior default actions are blocked,
 // the element is removed from tab order, and it matches `:disabled`.
 submitBehavior.disabled = true;
 labelBehavior.disabled = false;
 console.log(btn.matches(':disabled'));  // true
 ```
 
-For events, behavior responses follow the platform's existing default action model:
+For events, responses follow the platform's existing default action model:
 
 1. The event dispatches through the DOM.
 2. All author-registered event listeners run during dispatch.
-3. After dispatch completes, each behavior's default action runs unless a listener called `preventDefault()`.
+3. After dispatch completes, each element behavior's default action runs unless a listener called `preventDefault()`.
 
 When `btn` is clicked:
 - Author event listeners run during event dispatch.
 - `HTMLSubmitButtonBehavior`'s default action runs (form submits).
 - `HTMLLabelBehavior`'s default action runs (delegates focus to associated control).
-- If any listener called `preventDefault()`, both form submission and focus delegation are cancelled
-- `stopImmediatePropagation()` prevents subsequent listeners on the same element from running, but does not affect behavior default actions.
+- If any listener called `preventDefault()`, both form submission and focus delegation are canceled
+- `stopImmediatePropagation()` prevents subsequent listeners on the same element from running, but does not affect element behavior default actions.
 
 ### Feature detection
 
-Web authors can detect whether element behaviors are supported by checking for the existence of behavior classes on the global scope:
+Web authors can detect whether element behaviors are supported by checking for the existence of classes on the global scope:
 
 ```javascript
 if (typeof HTMLSubmitButtonBehavior !== 'undefined') {
@@ -366,16 +366,15 @@ This proposal supports common web component patterns:
 
 ### Use case: Design system button
 
-While this proposal only introduces `HTMLSubmitButtonBehavior`, the example below references `HTMLResetButtonBehavior` and `HTMLButtonBehavior` to illustrate how switching would work once additional behaviors become available in the future.
+While this proposal only introduces `HTMLSubmitButtonBehavior`, the example below references `HTMLResetButtonBehavior` and `HTMLButtonBehavior` to illustrate how switching would work once additional element behaviors become available in the future.
 
-A design system can use delayed `attachInternals()` to determine the behavior based on the initial `type` attribute. This approach uses a single class while keeping behaviors immutable after attachment.
+A design system can use delayed `attachInternals()` to determine the element behavior based on the initial `type` attribute. This approach uses a single class while keeping element behaviors immutable after attachment.
 
 ```javascript
 class DesignSystemButton extends HTMLElement {
   static formAssociated = true;
   static observedAttributes = ['type', 'disabled', 'formaction'];
 
-  // Behavior reference (set once in connectedCallback).
   #behavior = null;
   #internals = null;
 
@@ -385,7 +384,7 @@ class DesignSystemButton extends HTMLElement {
   }
 
   connectedCallback() {
-    // Attach behaviors once based on initial type attribute.
+    // Attach element behaviors once based on initial type attribute.
     if (!this.#internals) {
       const type = this.getAttribute('type') || 'button';
       this.#behavior = this.#createBehaviorForType(type);
@@ -432,7 +431,7 @@ class DesignSystemButton extends HTMLElement {
     }
   }
 
-  // Expose behavior properties.
+  // Expose element behavior properties.
   get disabled() {
     return this.#behavior?.disabled ?? false;
   }
@@ -491,16 +490,16 @@ The element gains:
 - Click and keyboard activation (Space/Enter).
 - Focusability (participates in tab order; removed when disabled).
 - Implicit ARIA `role="button"` that can be overridden by the web author.
-- Behavior-specific capabilities (form submission, reset, etc.) based on initial `type`.
+- Element behavior-specific capabilities (form submission, reset, etc.) based on initial `type`.
 - CSS pseudo-class matching: `:default`, `:disabled`/`:enabled`.
 - Participation in implicit form submission (for submit buttons).
-- Behavior properties like `disabled` and `formAction` are accessible via the stored behavior reference.
+- Element behavior properties like `disabled` and `formAction` are accessible via the stored `behavior` reference.
 
 *Note: Dynamically switching `type` after the element is connected is not supported because `internals.behaviors` can't be changed after `ElementInternals` is attached. If it turns out that dynamically switching `type` is needed, future work could consider removing this restriction.*
 
 ### Framework use cases
 
-#### Compatible behaviors
+#### Compatible element behaviors
 
 Call-to-action elements like "Sign Up" or "Download Now" often need to look like buttons but navigate to new pages. Web authors may:
 
@@ -596,7 +595,7 @@ customElements.define('nav-button', NavButton);
 <nav-button href="/dashboard">Sign Up</nav-button>
 ```
 
-These behaviors are *technically* compatible because:
+These element behaviors are *technically* compatible because:
 
 - Button provides keyboard activation (Space/Enter) and anchor provides navigation on the same `click` event.
 - They have complementary properties: button has `disabled`, anchor has `href`, `target`, `download`.
@@ -608,9 +607,9 @@ These behaviors are *technically* compatible because:
 2. Consider user expectations of screen reader users. They might expect buttons to perform actions and links to navigate.
 3. Test with assistive technologies to ensure the element behaves as users expect based on its announced role.
 
-Even with an explicit role, this pattern may confuse users who expect consistent functionality from elements announced as buttons or links. Authors should evaluate whether their use case requires both behaviors or if a single semantic (button or link) would better serve users.
+Even with an explicit role, this pattern may confuse users who expect consistent functionality from elements announced as buttons or links. Authors should evaluate whether their use case requires both element behaviors or if a single semantic (button or link) would better serve users.
 
-#### Conflicting behaviors
+#### Conflicting element behaviors
 
 Some element behaviors are inherently mutually exclusive.
 
@@ -645,7 +644,7 @@ The proposed pattern can be extended to additional element behaviors:
 
 Future element behaviors would also manage their own relevant pseudo-classes:
 
-| Behavior | CSS Pseudo-classes |
+| Element behavior | CSS Pseudo-classes |
 |----------|--------------------|
 | `HTMLCheckboxBehavior` | `:checked`, `:indeterminate` |
 | `HTMLInputBehavior` | `:valid`, `:invalid`, `:required`, `:optional`, `:placeholder-shown` |
@@ -654,11 +653,11 @@ Future element behaviors would also manage their own relevant pseudo-classes:
 
 ### Developer-defined behaviors
 
-A future extension of this proposal could allow developers to define their own reusable element behaviors by subclassing an `ElementBehavior` base class. This would enable patterns like custom tooltip behaviors, polyfilling upcoming element behaviors, and composing developer-defined behaviors with platform-provided ones.
+A future extension of this proposal could allow developers to define their own reusable element behaviors by subclassing an `ElementBehavior` base class. This would enable patterns like creating a custom tooltip, polyfilling upcoming element behaviors, and composing developer-defined behaviors with platform-provided ones.
 
 This direction is explored in a separate document: [Developer-defined behaviors](developer-defined-behaviors.md). It is not part of the current proposal and should be treated as forward-looking exploration.
 
-### Behaviors in native HTML elements
+### Element behaviors in native HTML elements
 
 Although this proposal currently focuses on custom elements, the `behavior` pattern could potentially be generalized to all HTML elements (e.g., a `<div>` element gains button capabilities via `ElementBehavior`). However, extending element behaviors to native HTML elements would raise questions about correctness and accessibility.
 
@@ -670,7 +669,7 @@ The American English spelling of behavior throughout this proposal follows the [
 
 - "behaviour" vs "behavior" may cause some friction for contributors.
 - Shorter names would improve ergonomics.
-- "Behavior" is used in other contexts (such as CSS scroll-behavior), which could cause confusion.
+- "Behavior" is used in other contexts (such as CSS `scroll-behavior`), which could cause confusion.
 
 Alternatives:
 
@@ -685,7 +684,7 @@ Alternatives:
 
 ### Alternative 1: Static Class Mixins
 
-Behaviors are exposed as functions that take a superclass and return a subclass.
+Capabilities are exposed as functions that take a superclass and return a subclass.
 
 ```javascript
 class CustomSubmitButton extends HTMLSubmitButtonMixin(HTMLElement) { ... }
@@ -697,14 +696,14 @@ class CustomSubmitButton extends HTMLSubmitButtonMixin(HTMLElement) { ... }
 
 **Cons:**
 - Functionality is fixed at class definition time (e.g. A design system couldn't offer a single `<ds-button>` that changes its abilities based on the `type` attribute as it would need separate classes like `<ds-submit-button>`, `<ds-reset-button>`, `<ds-button>`, increasing bundle sizes and API surface).
-- Authors might need to generate many class variations for different behavior combinations.
+- Authors might need to generate many class variations for different combinations.
 - It strictly binds functionality to the JavaScript class hierarchy, making a future declarative syntax hard to implement without creating new classes.
 
-Rejected in favor of the imperative API because it doesn't allow behavior composition (attaching multiple complementary behaviors to a single element), requires multiple classes instead of a single element that adapts to initial configuration, and doesn't support configuring behavior state before attachment.
+Rejected in favor of the imperative API because it doesn't allow composition (attaching multiple complementary capabilities to a single element), requires multiple classes instead of a single element that adapts to initial configuration, and doesn't support configuring element behavior state before attachment.
 
 ### Alternative 2: ElementInternals.type ([Proposed](../ElementInternalsType/explainer.md))
 
-Set a single "type" string that grants a predefined bundle of behaviors.
+Set a single "type" string that grants a predefined bundle of capabilities.
 
 ```javascript
 class CustomButton extends HTMLElement {
@@ -723,14 +722,14 @@ class CustomButton extends HTMLElement {
 
 **Cons:**
 - No composability as one custom element can only have one type.
-- Bundling capabilities can get confusing as it isn't obvious what capabilities and attributes are added.
+- Bundling functionality can get confusing as it isn't obvious what capabilities and attributes are added.
 - String APIs are error-prone and hard to debug.
 
 Too inflexible for the variety of use cases web developers need. While simpler, it doesn't solve the composability problem and it might be confusing for developers to use in practice.
 
 ### Alternative 3: Custom Attributes ([Proposed](https://github.com/WICG/webcomponents/issues/1029))
 
-Define custom attributes with lifecycle callbacks that add behavior to elements.
+Define custom attributes with lifecycle callbacks that add capabilities to elements.
 
 ```javascript
 class SubmitButtonAttribute extends Attribute {
@@ -787,9 +786,9 @@ customElements.define('fancy-button', FancyButton, { extends: 'button' });
 - [Limited Shadow DOM support](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#elements_you_can_attach_a_shadow_to) - only certain elements can be shadow hosts
 - Can't use `ElementInternals` API.
 - The `is=` syntax isn't considered developer-friendly to some.
-- Doesn't support composing behaviors from different base elements.
+- Doesn't support composition from different base elements.
 
-While customized built-ins are useful where supported, the issues listed above makes them unsuitable as the primary solution.
+While customized built-ins are useful where supported, the issues listed above make them unsuitable as the primary solution.
 
 ### Alternative 5: Expose certain behavioral attributes via ElementInternals (Proposed)
 
@@ -802,7 +801,7 @@ Expose specific behavioral attributes (like `popover`, `draggable`, `focusgroup`
 **Cons:**
 - Doesn't currently address form submission functionality.
 - Scoped to specific attributes rather than general capabilities.
-- Since the composition doesn't have an order/sequence to it, web authors would not be able to specify a desired "winner" when using multiple behaviors that happen to impact a shared value or capability.
+- Since the composition doesn't have an order/sequence to it, web authors would not be able to specify a desired "winner" when using multiple capabilities that happen to impact a shared value or capability.
 
 ### Alternative 6: Fully Customizable Native Elements
 
@@ -829,12 +828,12 @@ Expose individual primitives (focusability, disabled, keyboard activation) direc
 
 **Cons:**
 - Primitives like `disabled` and `focusable` interact with each other, with accessibility, and with event handling. Setting `internals.disabled = true` without the corresponding functionality might result in the element *looking* disabled but still receiving clicks, remaining in the tab order, and submitting with a form.
-- Even seemingly simple primitives like focusability could have significant complexity around accessibility integration. This is why `popovertarget` is limited to buttons(it was originally intended for any element, but the accessibility requirements around focusability and activation made buttons the practical choice). See [design-principles tradeoff between high-level and low-level APIs](https://www.w3.org/TR/design-principles/#high-level-low-level).
+- Even seemingly simple primitives like focusability could have significant complexity around accessibility integration. This is why `popovertarget` is limited to buttons (it was originally intended for any element, but the accessibility requirements around focusability and activation made buttons the practical choice). See [design-principles tradeoff between high-level and low-level APIs](https://www.w3.org/TR/design-principles/#high-level-low-level).
 - Form submission participation can be seen as a primitive itself (it can't be broken down further due to accessibility concerns).
 
 ### Alternative 8: TC39 Decorators
 
-Use [TC39 decorators](https://github.com/tc39/proposal-decorators) to attach behaviors to custom element classes.
+Use [TC39 decorators](https://github.com/tc39/proposal-decorators) to attach capabilities to custom element classes.
 
 ```javascript
 @HTMLSubmitButtonBehavior
@@ -853,11 +852,11 @@ class CustomButton extends HTMLElement {
 - Instance-specific configuration (e.g., setting `formAction` before attachment) isn't supported.
 - Decorators are inherently JavaScript syntax and don't support a future declarative, JavaScript-less approach to custom elements. This proposal's design decouples capabilities from the class definition, enabling future declarative syntax (see [Other considerations](#other-considerations)).
 
-`HTMLSubmitButtonBehavior` could itself be designed as a decorator, but decorators can't easily access `ElementInternals` or instance state during application. Decorators would need to coordinate with `attachInternals()` timing, and getting a reference to the behavior instance for property access (e.g., `behavior.formAction`) would require additional wiring.
+`HTMLSubmitButtonBehavior` could itself be designed as a decorator, but decorators can't easily access `ElementInternals` or instance state during application. Decorators would need to coordinate with `attachInternals()` timing, and getting a reference to the instance for property access (e.g., `behavior.formAction`) would require additional wiring.
 
 ### Alternative API design: Class references
 
-Pass behavior classes (not instances) to `attachInternals()`:
+Pass element behavior classes (not instances) to `attachInternals()`:
 
 ```javascript
 // Attach a behavior during initialization (class reference).
@@ -869,16 +868,16 @@ this._internals.behaviors.htmlSubmitButton.formAction = '/custom';
 
 **Pros:**
 - Named access via `this._internals.behaviors.<behaviorName>` requires no iteration.
-- Less setup code as developers don't manage behavior instances.
+- Less setup code as developers don't manage element behavior instances.
 
 **Cons:**
-- Platform instantiates the behavior, so constructor parameters aren't available. This conflicts with the [design principle that classes should have constructors](https://www.w3.org/TR/design-principles/#constructors) that allow authors to create and configure instances.
+- Platform instantiates the element behavior, so constructor parameters aren't available. This conflicts with the [design principle that classes should have constructors](https://www.w3.org/TR/design-principles/#constructors) that allow authors to create and configure instances.
 - Requires a `behaviors` interface for named access.
-- *Future* developer-defined behaviors would need a way to name their behaviors.
+- *Future* developer-defined behaviors would need a way to name their element behaviors.
 
 ### Alternative conflict resolution: Compatibility allow-list
 
-Compatibility between behaviors could be defined in the specification. This follows the pattern used by [`attachShadow`](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow), where the [list of valid shadow host names](https://dom.spec.whatwg.org/#valid-shadow-host-name) is spec-defined and enforced at runtime. Web authors can reference documentation or DevTools errors to determine which combinations are valid.
+Compatibility between element behaviors could be defined in the specification. This follows the pattern used by [`attachShadow`](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow), where the [list of valid shadow host names](https://dom.spec.whatwg.org/#valid-shadow-host-name) is spec-defined and enforced at runtime. Web authors can reference documentation or DevTools errors to determine which combinations are valid.
 
 Any combination not explicitly allowed would be rejected by `attachInternals()`, preventing invalid states (like being both a button and a form):
 
@@ -899,10 +898,10 @@ this.attachInternals({
 // Error message: "HTMLSubmitButtonBehavior is not compatible with HTMLCheckboxBehavior".
 ```
 
-There can be two interpretations of what "compatible behaviors" means:
+There can be two interpretations of what "compatible element behaviors" means:
 
-1. Compatible behaviors have completely disjoint capabilities (e.g., one provides `disabled`, the other provides `href`). No conflict resolution is needed because they never touch the same property or event.
-2. Compatible behaviors may share some capabilities (e.g., both provide a role or handle click). In this case, a conflict resolution strategy (order of precedence or explicit resolution) is still required for overlapping capabilities.
+1. Compatible element behaviors have completely disjoint capabilities (e.g., one provides `disabled`, the other provides `href`). No conflict resolution is needed because they never touch the same property or event.
+2. Compatible element behaviors may share some capabilities (e.g., both provide a role or handle click). In this case, a conflict resolution strategy (order of precedence or explicit resolution) is still required for overlapping capabilities.
 
 **Pros:**
 - Clear error messages guide developers to do the *right thing*.

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -10,26 +10,26 @@
 
 ## Introduction
 
-Custom element authors frequently need their elements to use platform behaviors that are currently exclusive to native HTML elements, such as [form submission](https://github.com/WICG/webcomponents/issues/814), [popover invocation](https://github.com/whatwg/html/issues/9110), [label behaviors](https://github.com/whatwg/html/issues/5423#issuecomment-1517653183), [form semantics](https://github.com/whatwg/html/issues/10220), and [radio button grouping](https://github.com/whatwg/html/issues/11061#issuecomment-3250415103). This proposal introduces platform-provided behaviors as a mechanism for autonomous custom elements to adopt specific native HTML element behaviors. Rather than requiring developers to reimplement native behaviors in JavaScript or extend native elements (customized built-ins), this approach exposes native capabilities as composable behaviors.
+Custom element authors frequently need their elements to use platform capabilities that are currently exclusive to native HTML elements, such as [form submission](https://github.com/WICG/webcomponents/issues/814), [popover invocation](https://github.com/whatwg/html/issues/9110), [label association](https://github.com/whatwg/html/issues/5423#issuecomment-1517653183), [form semantics](https://github.com/whatwg/html/issues/10220), and [radio button grouping](https://github.com/whatwg/html/issues/11061#issuecomment-3250415103). This proposal introduces platform-provided behaviors as a mechanism for autonomous custom elements to adopt specific native HTML element capabilities. Rather than requiring developers to reimplement native functionality in JavaScript or extend native elements (customized built-ins), this approach exposes native capabilities as composable element behaviors.
 
 ## User-facing problem
 
-Custom element authors can't access native behaviors that are built into native HTML elements. This forces them to either:
+Custom element authors can't access native capabilities that are built into native HTML elements. This forces them to either:
 
 1. Use customized built-ins (`is/extends` syntax), which have [Shadow DOM limitations](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#elements_you_can_attach_a_shadow_to) and [can't use the ElementInternals API](https://github.com/whatwg/html/issues/5166).
-2. Try to reimplement native logic in JavaScript, which is error-prone, often less performant, and cannot replicate certain platform-internal behaviors.
+2. Try to reimplement native logic in JavaScript, which is error-prone, often less performant, and cannot replicate certain platform-internal functionality.
 3. Accept that their custom elements simply can't do what native elements can do.
 
 This creates a gap between what's possible with native elements and custom elements, limiting web components and forcing developers into suboptimal patterns.
 
 ### Goals
 
-- Establish an extensible framework for custom elements to adopt native behaviors for built in elements.
+- Establish an extensible framework for custom elements to adopt native capabilities of built-in elements.
 - Enable autonomous custom elements to trigger form submission like `<button type="submit">` as the initial capability of this framework.
 
 ### Non-goals
 
-- Recreating all native element behaviors in this initial proposal.
+- Recreating all native element capabilities in this initial proposal.
 - Making updates to customized built-ins.
 
 ## User research
@@ -74,12 +74,12 @@ This proposal is informed by:
 ### Why start with form submission?
 
 1. There's a clear gap with implicit form submission.
-2. Form submission has clear semantics, making it useful for validating the overall pattern (lifecycle, conflict resolution, accessibility integration) before expanding to more complex behaviors.
+2. Form submission has clear semantics, making it useful for validating the overall pattern (lifecycle, conflict resolution, accessibility integration) before expanding to more complex element behaviors.
 3. There's no API to make a custom element participate in implicit form submission as `form.requestSubmit()` only handles explicit activation.
 
 ## Proposed approach
 
-This proposal introduces a `behaviors` option to `attachInternals()`. Behaviors are instantiated with `new` and attached via the options object. Once attached, behaviors can't be added, removed, or replaced but the behavior instances themselves remain mutable.
+This proposal introduces a `behaviors` option to `attachInternals()`. Element behaviors are instantiated with `new` and attached via the options object. Once attached, element behaviors can't be added, removed, or replaced but the behavior instances themselves remain mutable.
 
 ```javascript
 // Instantiate the behavior and attach it.
@@ -98,7 +98,7 @@ submitBehavior?.disabled = true;
 
 ### Platform-provided behaviors
 
-Platform behaviors give custom elements capabilities that would otherwise require reimplementation or workarounds. Each behavior automatically provides:
+Platform-provided behaviors give custom elements capabilities that would otherwise require reimplementation or workarounds. Each one automatically provides:
 
 - Event handling: Platform events (click, keydown, etc.) are wired up automatically using the standard DOM event infrastructure (respecting `stopPropagation`, `preventDefault`, etc.)
 - ARIA defaults: Implicit roles and properties for accessibility.
@@ -117,19 +117,19 @@ This proposal introduces `HTMLSubmitButtonBehavior`, which mirrors the submissio
 | Focusability | Participates in tab order; removed when `disabled` is `true`. |
 | CSS pseudo-classes | `:default`, `:disabled`/`:enabled`, `:focus`, `:focus-visible`. |
 
-*Note: While `HTMLButtonElement` also supports generic button behavior (type="button") and reset behavior (type="reset"), this proposal focuses exclusively on introducing the submit behavior.*
+*Note: While `HTMLButtonElement` also supports generic button functionality (type="button") and reset functionality (type="reset"), this proposal focuses exclusively on introducing the submit functionality.*
 
 `HTMLSubmitButtonBehavior` doesn't require the custom element to be form-associated (`static formAssociated = true`), but form association is needed for submission to work. Without it, `behavior.form` is always `null` and activation is a no-op even if the element is inside a form. This is a divergence from native `<button>`, which submits its form without any explicit opt-in.
 
-| Scenario | Behavior |
-|----------|----------|
+| Scenario | Effect |
+|----------|--------|
 | Form-associated element inside a form | Full functionality: activation triggers submission, participates in implicit submission, matches `:default`. |
 | Form-associated element outside a form | `behavior.form` returns `null`, activation is a no-op (like a native button outside a form). |
 | Non-form-associated element | `behavior.form` is `null`, activation is a no-op even inside a form. Implicit submission and `:default` don't apply. The element still gets `role="button"` and implicit focusability. |
 
 ### Accessing behavior state
 
-Each behavior exposes properties and methods from its corresponding native element. Behaviors can be accessed directly via the stored reference. For `HTMLSubmitButtonBehavior`, the following properties are available (mirroring [`HTMLButtonElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement)):
+Each behavior exposes properties and methods from its corresponding native element. Element behaviors can be accessed directly via the stored reference. For `HTMLSubmitButtonBehavior`, the following properties are available (mirroring [`HTMLButtonElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement)):
 
 **Properties:**
 - `disabled` - The element is effectively disabled if either `behavior.disabled` is `true` or the element is disabled via attribute or is a descendant of `<fieldset disabled>` ([spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled)).
@@ -187,7 +187,7 @@ class CustomButton extends HTMLElement {
 }
 ```
 
-Form override values (`formAction`, `formEnctype`, `formMethod`, `formNoValidate`, `formTarget`, `name`, `value`) are read from `behavior` properties. Setting a value declaratively in markup (e.g., `<my-button formaction="/save">`) or programmatically (e.g. `setAttribute('formaction', '/save')`) has no effect on form submission unless the author explicitly forwards that attribute to the `behavior`. However, some element attributes are applied to form submission as part of the existing [form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-elements) mechanism, independently of behaviors:
+Form override values (`formAction`, `formEnctype`, `formMethod`, `formNoValidate`, `formTarget`, `name`, `value`) are read from `behavior` properties. Setting a value declaratively in markup (e.g., `<my-button formaction="/save">`) or programmatically (e.g. `setAttribute('formaction', '/save')`) has no effect on form submission unless the author explicitly forwards that attribute to the `behavior`. However, some element attributes are applied to form submission as part of the existing [form-associated custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-elements) mechanism, independently of element behaviors:
 
 | Element attribute | Applied via form-associated custom element mechanics | Notes |
 |-------------------|------------------------------------------------------|-------|
@@ -198,7 +198,7 @@ Form override values (`formAction`, `formEnctype`, `formMethod`, `formNoValidate
 
 ### Behavior lifecycle
 
-When `attachInternals()` is called with behaviors, each behavior is attached to the element:
+When `attachInternals()` is called with element behaviors, each one is attached to the element:
 
 | Event | Effect |
 |-------|--------|
@@ -206,7 +206,7 @@ When `attachInternals()` is called with behaviors, each behavior is attached to 
 | Element disconnected from DOM | Behavior state is preserved. Event handlers remain conceptually attached but inactive. |
 | Element reconnected to DOM | Event handlers become active again. Behavior state (e.g., `formAction`, `disabled`) is preserved. |
 
-*Note: Behaviors are immutable after `attachInternals()`. Dynamic behavior updates (adding, removing, or replacing behaviors after attachment) are not supported, as developer feedback indicated that the problems with `<input>`'s mutable `type` attribute (state migration, event handler cleanup, property compatibility) should not be replicated.*
+*Note: Element behaviors are immutable after `attachInternals()`. Dynamic updates (adding, removing, or replacing element behaviors after attachment) are not supported, as developer feedback indicated that the problems with `<input>`'s mutable `type` attribute (state migration, event handler cleanup, property compatibility) should not be replicated.*
 
 ### Duplicate behaviors
 
@@ -240,15 +240,15 @@ This ensures that element-specific properties like `behavior.form` and `behavior
 
 ### API design
 
-Behaviors are instantiated with `new` and passed to `attachInternals()`:
+Element behaviors are instantiated with `new` and passed to `attachInternals()`:
 
-- `behaviors` option in `attachInternals({ behaviors: [...] })` accepts behavior instances.
+- `behaviors` option in `attachInternals({ behaviors: [...] })` accepts element behavior instances.
 - `behaviors` property on `ElementInternals` is a read-only `FrozenArray`.
-- Developers hold direct references to their behavior instances.
+- Developers hold direct references to their element behavior instances.
 
-*Note: An ordered array is preferred over a set because order may be significant for [conflict resolution](#behavior-composition-and-conflict-resolution). `behaviors` uses a `FrozenArray` because behaviors are immutable after attachment.*
+*Note: An ordered array is preferred over a set because order may be significant for [conflict resolution](#behavior-composition-and-conflict-resolution). `behaviors` uses a `FrozenArray` because element behaviors are immutable after attachment.*
 
-Developers hold direct references to their behavior instances. This follows the [W3C design principle that classes should have constructors](https://www.w3.org/TR/design-principles/#constructors) that allow authors to create and configure instances, and it extends naturally to future developer-defined behaviors that follow the same `new` + attach pattern.
+Developers hold direct references to their element behavior instances. This follows the [W3C design principle that classes should have constructors](https://www.w3.org/TR/design-principles/#constructors) that allow authors to create and configure instances, and it extends naturally to future developer-defined element behaviors that follow the same `new` + attach pattern.
 
 *For future developer-defined behaviors:*
 
@@ -272,7 +272,7 @@ this._tooltipBehavior.content = 'Helpful tooltip text';
 
 ### Behavior composition and conflict resolution
 
-For the built-in behaviors currently under consideration and mentioned in this document (`HTMLSubmitButtonBehavior`, `HTMLButtonBehavior`, `HTMLResetButtonBehavior`, etc.), there probably isn't a practical use case for combining them. However, attaching multiple behaviors is not prohibited. If multiple behaviors are provided, conflicts are resolved using order of precedence: the position of behaviors in the array determines which behavior's value takes effect.
+For the element behaviors currently under consideration and mentioned in this document (`HTMLSubmitButtonBehavior`, `HTMLButtonBehavior`, `HTMLResetButtonBehavior`, etc.), there probably isn't a practical use case for combining them. However, attaching multiple element behaviors is not prohibited. If multiple element behaviors are provided, conflicts are resolved using order of precedence: the position of behaviors in the array determines which behavior's value takes effect.
 
 Consider the following example of behaviors that could potentially be compatible, `HTMLLabelBehavior` and `HTMLSubmitButtonBehavior`:
 
@@ -330,11 +330,11 @@ When `btn` is clicked:
 
 ### Feature detection
 
-Web authors can detect whether behaviors are supported by checking for the existence of behavior classes on the global scope:
+Web authors can detect whether element behaviors are supported by checking for the existence of behavior classes on the global scope:
 
 ```javascript
 if (typeof HTMLSubmitButtonBehavior !== 'undefined') {
-  // Behaviors are supported.
+  // Element behaviors are supported.
   this._submitBehavior = new HTMLSubmitButtonBehavior();
   this._internals = this.attachInternals({ behaviors: [this._submitBehavior] });
 } else {
@@ -350,12 +350,12 @@ if (typeof HTMLSubmitButtonBehavior !== 'undefined') {
 
 This proposal supports common web component patterns:
 
-- A child class extends the parent's functionality and retains access to the `ElementInternals` object and its active behaviors.
-- `HTMLSubmitButtonBehavior` and subsequent platform-provided behaviors should be understood as bundles of state, event handlers, and accessibility defaults and not opaque tokens. Web authors can reason about what a behavior provides (e.g., click/Enter triggers form submission, implicit `role="button"`, focusability, `:disabled` pseudo-class) and anticipate how it composes with other behaviors. This framework would also enable polyfilling: because behaviors have well-defined capabilities, authors can approximate new behaviors in *userland* before native support ships (see [Developer-defined behaviors](#developer-defined-behaviors) in [Future Work](#future-work)).
-- This proposal targets autonomous custom elements that need platform behaviors (e.g., when needing Shadow DOM and custom APIs or building a design system component that is an autonomous custom element). Making native elements more flexible (Customizable Select, open-stylable controls) is valuable and complementary, but doesn't completely eliminate the need for autonomous custom elements.
-- Platform-provided behaviors are JavaScript-dependent, as is any autonomous custom element. If script fails to load, the element receives no behavior—this is true with or without this proposal.
-- Custom elements using behaviors can still follow progressive enhancement patterns: use `<slot>` to render fallback content, provide `<noscript>` alternatives, and design markup to be readable without JavaScript.
-- While this proposal uses an imperative API, the design supports future declarative custom elements. Once a declarative syntax for `ElementInternals` is established, attaching behaviors could be modeled as an attribute, decoupling behavior from the JavaScript class definition. The following snippet shows a hypothetical example:
+- A child class extends the parent's functionality and retains access to the `ElementInternals` object and its active element behaviors.
+- `HTMLSubmitButtonBehavior` and subsequent platform-provided behaviors should be understood as bundles of state, event handlers, and accessibility defaults and not opaque tokens. Web authors can reason about what an element behavior provides (e.g., click/Enter triggers form submission, implicit `role="button"`, focusability, `:disabled` pseudo-class) and anticipate how it composes with other element behaviors. This framework would also enable polyfilling: because element behaviors have well-defined capabilities, authors can approximate new element behaviors in *userland* before native support ships (see [Developer-defined behaviors](#developer-defined-behaviors) in [Future Work](#future-work)).
+- This proposal targets autonomous custom elements that need platform capabilities (e.g., when needing Shadow DOM and custom APIs or building a design system component that is an autonomous custom element). Making native elements more flexible (Customizable Select, open-stylable controls) is valuable and complementary, but doesn't completely eliminate the need for autonomous custom elements.
+- Platform-provided behaviors are JavaScript-dependent, as is any autonomous custom element. If script fails to load, the element receives no element behavior—this is true with or without this proposal.
+- Custom elements using element behaviors can still follow progressive enhancement patterns: use `<slot>` to render fallback content, provide `<noscript>` alternatives, and design markup to be readable without JavaScript.
+- While this proposal uses an imperative API, the design supports future declarative custom elements. Once a declarative syntax for `ElementInternals` is established, attaching element behaviors could be modeled as an attribute, decoupling functionality from the JavaScript class definition. The following snippet shows a hypothetical example:
 
   ```html
   <custom-button name="custom-submit-button">
@@ -544,7 +544,7 @@ Call-to-action elements like "Sign Up" or "Download Now" often need to look like
     document.head.appendChild(link);
   });
 
-  // To implement download behavior author would have to create a temporary <a> element.
+  // To implement download functionality author would have to create a temporary <a> element.
 </script>
 ```
 
@@ -608,11 +608,11 @@ These behaviors are *technically* compatible because:
 2. Consider user expectations of screen reader users. They might expect buttons to perform actions and links to navigate.
 3. Test with assistive technologies to ensure the element behaves as users expect based on its announced role.
 
-Even with an explicit role, this pattern may confuse users who expect consistent behavior from elements announced as buttons or links. Authors should evaluate whether their use case requires both behaviors or if a single semantic (button or link) would better serve users.
+Even with an explicit role, this pattern may confuse users who expect consistent functionality from elements announced as buttons or links. Authors should evaluate whether their use case requires both behaviors or if a single semantic (button or link) would better serve users.
 
 #### Conflicting behaviors
 
-Some behaviors are inherently mutually exclusive.
+Some element behaviors are inherently mutually exclusive.
 
 ```javascript
 this._checkboxBehavior = new HTMLCheckboxBehavior();
@@ -633,7 +633,7 @@ The result is incoherent: the element has radio semantics for the `checked` prop
 
 ## Future work
 
-The behavior pattern can be extended to additional behaviors:
+The proposed pattern can be extended to additional element behaviors:
 
 - **Generic Buttons**: `HTMLButtonBehavior` for non-submitting buttons (popover invocation, commands).
 - **Reset Buttons**: `HTMLResetButtonBehavior` for form resetting.
@@ -643,7 +643,7 @@ The behavior pattern can be extended to additional behaviors:
 - **Radio Groups**: `HTMLRadioGroupBehavior` for `name`-based mutual exclusion.
 - **Tables**: `HTMLTableBehavior` for table layout semantics and accessibility.
 
-Future behaviors would also manage their own relevant pseudo-classes:
+Future element behaviors would also manage their own relevant pseudo-classes:
 
 | Behavior | CSS Pseudo-classes |
 |----------|--------------------|
@@ -654,13 +654,13 @@ Future behaviors would also manage their own relevant pseudo-classes:
 
 ### Developer-defined behaviors
 
-A future extension of this proposal could allow developers to define their own reusable behaviors by subclassing an `ElementBehavior` base class. This would enable patterns like custom tooltip behaviors, polyfilling upcoming platform behaviors, and composing developer-defined behaviors with platform-provided ones.
+A future extension of this proposal could allow developers to define their own reusable element behaviors by subclassing an `ElementBehavior` base class. This would enable patterns like custom tooltip behaviors, polyfilling upcoming element behaviors, and composing developer-defined behaviors with platform-provided ones.
 
 This direction is explored in a separate document: [Developer-defined behaviors](developer-defined-behaviors.md). It is not part of the current proposal and should be treated as forward-looking exploration.
 
 ### Behaviors in native HTML elements
 
-Although this proposal currently focuses on custom elements, the behavior pattern could potentially be generalized to all HTML elements (e.g., a `<div>` element gains button behavior via behaviors). However, extending behaviors to native HTML elements would raise questions about correctness and accessibility.
+Although this proposal currently focuses on custom elements, the `behavior` pattern could potentially be generalized to all HTML elements (e.g., a `<div>` element gains button capabilities via `ElementBehavior`). However, extending element behaviors to native HTML elements would raise questions about correctness and accessibility.
 
 ## Open questions
 
@@ -696,9 +696,9 @@ class CustomSubmitButton extends HTMLSubmitButtonMixin(HTMLElement) { ... }
 - Prototype-based composition.
 
 **Cons:**
-- Behavior is fixed at class definition time (e.g. A design system couldn't offer a single `<ds-button>` that changes behavior based on the `type` attribute as it would need separate classes like `<ds-submit-button>`, `<ds-reset-button>`, `<ds-button>`, increasing bundle sizes and API surface).
+- Functionality is fixed at class definition time (e.g. A design system couldn't offer a single `<ds-button>` that changes its abilities based on the `type` attribute as it would need separate classes like `<ds-submit-button>`, `<ds-reset-button>`, `<ds-button>`, increasing bundle sizes and API surface).
 - Authors might need to generate many class variations for different behavior combinations.
-- It strictly binds behavior to the JavaScript class hierarchy, making a future declarative syntax hard to implement without creating new classes.
+- It strictly binds functionality to the JavaScript class hierarchy, making a future declarative syntax hard to implement without creating new classes.
 
 Rejected in favor of the imperative API because it doesn't allow behavior composition (attaching multiple complementary behaviors to a single element), requires multiple classes instead of a single element that adapts to initial configuration, and doesn't support configuring behavior state before attachment.
 
@@ -723,7 +723,7 @@ class CustomButton extends HTMLElement {
 
 **Cons:**
 - No composability as one custom element can only have one type.
-- Bundling behavior can get confusing as it isn't obvious what behaviors and attributes are added.
+- Bundling capabilities can get confusing as it isn't obvious what capabilities and attributes are added.
 - String APIs are error-prone and hard to debug.
 
 Too inflexible for the variety of use cases web developers need. While simpler, it doesn't solve the composability problem and it might be confusing for developers to use in practice.
@@ -753,13 +753,13 @@ HTMLElement.attributeRegistry.define('submit-button', SubmitButtonAttribute);
 - Would provide composability (multiple attributes).
 
 **Cons:**
-- Would require authors to implement all behavior in JavaScript (no access to platform internals).
+- Would require authors to implement all functionality in JavaScript (no access to platform internals).
 - There are performance concerns with `Attr` node creation.
 - Namespace conflicts need resolution.
 - Doesn't solve the platform integration problem.
 - Still a proposal without implementation commitment.
 
-Custom attributes are complementary but don't provide access to native behaviors. They're useful for *userland* behavior composition but can't trigger form submission, invoke popovers through platform code, etc.
+Custom attributes are complementary but don't provide access to native capabilities. They're useful for *userland* capability composition but can't trigger form submission, invoke popovers through platform code, etc.
 
 ### Alternative 4: Customized Built-ins
 
@@ -779,7 +779,7 @@ customElements.define('fancy-button', FancyButton, { extends: 'button' });
 ```
 
 **Pros:**
-- Full access to all native behaviors.
+- Full access to all native capabilities.
 - Natural inheritance model.
 
 **Cons:**
@@ -800,9 +800,9 @@ Expose specific behavioral attributes (like `popover`, `draggable`, `focusgroup`
 - Hides implementation details from the consumer.
 
 **Cons:**
-- Doesn't currently address form submission behavior.
-- Scoped to specific attributes rather than general behaviors.
-- Since the composition doesn't have an order/sequence to it, web authors would not be able to specify a desired "winner" when using multiple behaviors that happen to impact a shared value or behavior.
+- Doesn't currently address form submission functionality.
+- Scoped to specific attributes rather than general capabilities.
+- Since the composition doesn't have an order/sequence to it, web authors would not be able to specify a desired "winner" when using multiple behaviors that happen to impact a shared value or capability.
 
 ### Alternative 6: Fully Customizable Native Elements
 
@@ -810,14 +810,14 @@ Modify existing native HTML elements to be fully stylable and customizable, simi
 
 **Pros:**
 - Developers can use standard HTML elements (`<button>`, `<select>`, etc.) without needing custom elements.
-- Accessibility and behavior are handled entirely by the browser.
+- Accessibility and functionality are handled entirely by the browser.
 
 **Cons:**
 - Requires specification and implementation for every single HTML element.
 - Does not help developers who need to create a custom element for semantic or architectural reasons (e.g., a specific design system component with custom API).
 - Doesn't solve the problem of "autonomous custom elements" needing native capabilities; it just improves native elements.
 
-While valuable, this can be a parallel effort. Even if all native elements were customizable, there would still be valid use cases for autonomous custom elements that need to participate in native behaviors (like form submission) while maintaining their own identity and API.
+While valuable, this can be a parallel effort. Even if all native elements were customizable, there would still be valid use cases for autonomous custom elements that need to participate in native capabilities (like form submission) while maintaining their own identity and API.
 
 ### Alternative 7: Low-level primitives on ElementInternals
 
@@ -828,7 +828,7 @@ Expose individual primitives (focusability, disabled, keyboard activation) direc
 - Each primitive is independently useful.
 
 **Cons:**
-- Primitives like `disabled` and `focusable` interact with each other, with accessibility, and with event handling. Setting `internals.disabled = true` without the associated behavior might result in the element *looking* disabled but still receiving clicks, remaining in the tab order, and submitting with a form.
+- Primitives like `disabled` and `focusable` interact with each other, with accessibility, and with event handling. Setting `internals.disabled = true` without the corresponding functionality might result in the element *looking* disabled but still receiving clicks, remaining in the tab order, and submitting with a form.
 - Even seemingly simple primitives like focusability could have significant complexity around accessibility integration. This is why `popovertarget` is limited to buttons(it was originally intended for any element, but the accessibility requirements around focusability and activation made buttons the practical choice). See [design-principles tradeoff between high-level and low-level APIs](https://www.w3.org/TR/design-principles/#high-level-low-level).
 - Form submission participation can be seen as a primitive itself (it can't be broken down further due to accessibility concerns).
 
@@ -839,7 +839,7 @@ Use [TC39 decorators](https://github.com/tc39/proposal-decorators) to attach beh
 ```javascript
 @HTMLSubmitButtonBehavior
 class CustomButton extends HTMLElement {
-  // Decorator applies submit button behavior to the class.
+  // Decorator applies submit button capabilities to the class.
 }
 ```
 
@@ -849,9 +849,9 @@ class CustomButton extends HTMLElement {
 - Allows composition.
 
 **Cons:**
-- Decorators operate at class definition time, not instance creation time. This creates the same limitation as static class mixins: behavior is fixed when the class is defined, not when instances are created (e.g., a design system couldn't offer a single `<ds-button>` class that adapts behavior based on the `type` attribute).
-- Instance-specific behavior configuration (e.g., setting `formAction` before attachment) isn't supported.
-- Decorators are inherently JavaScript syntax and don't support a future declarative, JavaScript-less approach to custom elements. This proposal's design decouples behaviors from the class definition, enabling future declarative syntax (see [Other considerations](#other-considerations)).
+- Decorators operate at class definition time, not instance creation time. This creates the same limitation as static class mixins: functionality is fixed when the class is defined, not when instances are created (e.g., a design system couldn't offer a single `<ds-button>` class that adapts its functionality based on the `type` attribute).
+- Instance-specific configuration (e.g., setting `formAction` before attachment) isn't supported.
+- Decorators are inherently JavaScript syntax and don't support a future declarative, JavaScript-less approach to custom elements. This proposal's design decouples capabilities from the class definition, enabling future declarative syntax (see [Other considerations](#other-considerations)).
 
 `HTMLSubmitButtonBehavior` could itself be designed as a decorator, but decorators can't easily access `ElementInternals` or instance state during application. Decorators would need to coordinate with `attachInternals()` timing, and getting a reference to the behavior instance for property access (e.g., `behavior.formAction`) would require additional wiring.
 
@@ -942,19 +942,19 @@ this._internals = this.attachInternals({
 
 ### Accessibility
 
-- Platform behaviors must provide appropriate default ARIA roles and states (e.g., `role="button"` for `HTMLSubmitButtonBehavior`).
+- Platform-provided behaviors must set appropriate default ARIA roles and states (e.g., `role="button"` for `HTMLSubmitButtonBehavior`).
 - Custom elements using a platform-provided behavior must gain the same keyboard handling and focus management as their native counterparts (e.g., Space/Enter activation).
-- Authors must be able to override default semantics using `ElementInternals.role` and `ElementInternals.aria*` properties if the default behavior does not match their specific use case.
+- Authors must be able to override default semantics using `ElementInternals.role` and `ElementInternals.aria*` properties if the default semantics do not match their specific use case.
 
 ### Security
 
 - This proposal exposes existing platform capabilities to custom elements, rather than introducing new capabilities.
-- Form submission triggered by behaviors must respect the same security policies as native form submission.
-- All security checks that apply to native elements (e.g., form validation, submission restrictions) apply to custom elements using these behaviors.
+- Form submission triggered by platform-provided behaviors must respect the same security policies as native form submission.
+- All security checks that apply to native elements (e.g., form validation, submission restrictions) apply to custom elements using these platform-provided behaviors.
 
 ### Privacy
 
-- The presence of specific behaviors in the API surface can be used for fingerprinting or browser version detection. This is consistent with the introduction of any new Web Platform feature.
+- The presence of specific platform-provided behaviors in the API surface can be used for fingerprinting or browser version detection. This is consistent with the introduction of any new Web Platform feature.
 - This proposal does not introduce new mechanisms for collecting or transmitting user data beyond what is already possible with native HTML elements.
 
 ## Stakeholder feedback / opposition

--- a/PlatformProvidedBehaviors/explainer.md
+++ b/PlatformProvidedBehaviors/explainer.md
@@ -699,7 +699,7 @@ class CustomSubmitButton extends HTMLSubmitButtonMixin(HTMLElement) { ... }
 - Authors might need to generate many class variations for different combinations.
 - It strictly binds functionality to the JavaScript class hierarchy, making a future declarative syntax hard to implement without creating new classes.
 
-Rejected in favor of the imperative API because it doesn't allow composition (attaching multiple complementary capabilities to a single element), requires multiple classes instead of a single element that adapts to initial configuration, and doesn't support configuring element behavior state before attachment.
+Rejected in favor of the imperative API because it doesn't allow composition (attaching multiple complementary capabilities to a single element), requires multiple classes instead of a single element that adapts to initial configuration, and doesn't support configuring its capabilities state before attachment.
 
 ### Alternative 2: ElementInternals.type ([Proposed](../ElementInternalsType/explainer.md))
 
@@ -801,7 +801,7 @@ Expose specific behavioral attributes (like `popover`, `draggable`, `focusgroup`
 **Cons:**
 - Doesn't currently address form submission functionality.
 - Scoped to specific attributes rather than general capabilities.
-- Since the composition doesn't have an order/sequence to it, web authors would not be able to specify a desired "winner" when using multiple capabilities that happen to impact a shared value or capability.
+- Since the composition doesn't have an order/sequence to it, web authors would not be able to specify a desired "winner" when using multiple capabilities that happen to impact a shared value or functionality.
 
 ### Alternative 6: Fully Customizable Native Elements
 


### PR DESCRIPTION
# Updates
- Use of `behavior` and `behaviors` throughout the document:
  - Either changed them to `capabilities`/`functionality` to disambiguate references to `ElementBehavior` child classes, or
  - Clarified as `element behaviors` to refer to child classes like `HTMLSubmitButtonBehavior`, `HTMLResetButtonBehavior`, etc.