### PR TITLE
[CSS Modules] Move breaking change notice to the end of the document

### DIFF
--- a/ShadowDOM/explainer.md
+++ b/ShadowDOM/explainer.md
@@ -1,34 +1,5 @@
 # Declarative adoptedStyleSheets for Sharing Styles In Declarative Shadow DOM
 
-## June 2026 Breaking Change in Origin Trial
-
-An [Origin Trial](https://chromestatus.com/feature/4790543041298432) was started in Edge/Chrome 148.
-
-Due to feedback, the `<style type="module">` part of this proposal will be redesigned. Starting in Edge/Chrome 151, the Origin Trial
-will no longer include `<style type="module">` functionality, and will be scoped to only enable `shadowrootadoptedstylesheets`.
-
-A workaround for the lack of `<style type="module">` support is to use Import Maps with a data URI. A style module that was defined as follows:
-
-```html
-<style type="module" specifier="foo">
-  span {color: blue;}
-</style>
-```
-
-...can instead be expressed as:
-
-```html
-<script type="importmap">
-{
-  "imports": {
-    "foo": "data:text/css,span{color:blue;}"
-  }
-}
-</script>
-```
-
-This is the recommended approach while we redesign `<style type="module">`.
-
 ## Authors
 
 - Kurt Catti-Schmidt
@@ -93,6 +64,7 @@ content location of future work and discussions.
   - [Future work](#future-work)
   - [Summary](#summary)
   - [Open issues](#open-issues)
+  - [June 2026 Breaking Change in Origin Trial](#june-2026-breaking-change-in-origin-trial)
   - [References and acknowledgements](#references-and-acknowledgements)
 
 
@@ -783,6 +755,36 @@ The following table compares pros and cons of the various proposals:
 * What happens in scenarios that cross document boundaries, such as `Document.parseHTMLUnsafe`?
 
 For open issues specific to the `shadowrootadoptedstylesheets` attribute (polyfill detection, non-constructable stylesheets, fetch error handling, etc.), see [Open issues](../ShadowDOMAdoptedStyleSheets/explainer.md#open-issues) in the focused `shadowrootadoptedstylesheets` explainer.
+
+
+## June 2026 Breaking Change in Origin Trial
+
+An [Origin Trial](https://chromestatus.com/feature/4790543041298432) was started in Edge/Chrome 148.
+
+Due to feedback, the `<style type="module">` part of this proposal will be redesigned. Starting in Edge/Chrome 151, the Origin Trial
+will no longer include `<style type="module">` functionality, and will be scoped to only enable `shadowrootadoptedstylesheets`.
+
+A workaround for the lack of `<style type="module">` support is to use Import Maps with a data URI. A style module that was defined as follows:
+
+```html
+<style type="module" specifier="foo">
+  span {color: blue;}
+</style>
+```
+
+...can instead be expressed as:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "foo": "data:text/css,span{color:blue;}"
+  }
+}
+</script>
+```
+
+This is the recommended approach while we redesign `<style type="module">`.
 
 ## References and acknowledgements
 Many thanks for valuable feedback and advice from other contributors:


### PR DESCRIPTION
Now that the breaking change has been in Canary for a few weeks, we can move this towards the end of the document. It has already created confusion in standards threads, so it's better to do this sooner than later.