### PR TITLE
[Slotted options] Add backticks to select in link to keep it from eating the whole doc

### DIFF
--- a/SlottedOption/explainer.md
+++ b/SlottedOption/explainer.md
@@ -21,7 +21,7 @@ to keep the community up to date.
 
 - This document status: **Archived**
 - Expected venue: [WHATWG HTML](https://html.spec.whatwg.org/)
-- Current version: [Slotted Options in <select> - OpenUI](https://open-ui.org/components/select.slotted.option/)
+- Current version: [Slotted Options in `<select>` - OpenUI](https://open-ui.org/components/select.slotted.option/)
 
 ## Table of Contents
 


### PR DESCRIPTION
The "`<select>`" in the link to the new explainer was being treated as an actual `<select>` by the markdown parser resulting in a mangled document. Fix it by adding backticks.